### PR TITLE
fix: apply the same logic for searching spec files and tsconfig as th…

### DIFF
--- a/packages/tscc-spec/src/TsccSpec.ts
+++ b/packages/tscc-spec/src/TsccSpec.ts
@@ -85,7 +85,7 @@ export default class TsccSpec implements ITsccSpec {
 				TsccSpec.resolveTsccSpec(tsccSpecJSONOrItsPath) :
 				typeof tsccSpecJSONOrItsPath === 'object' ?
 					hasSpecFileKey(tsccSpecJSONOrItsPath) ?
-						TsccSpec.resolveFile(tsccSpecJSONOrItsPath.specFile) :
+						TsccSpec.resolveTsccSpec(tsccSpecJSONOrItsPath.specFile) :
 						path.join(process.cwd(), TsccSpec.SPEC_FILE) : // Just a dummy path
 					TsccSpec.resolveTsccSpec(undefined); // Searches in ancestor directories
 

--- a/packages/tscc-spec/test/TsccSpec.ts
+++ b/packages/tscc-spec/test/TsccSpec.ts
@@ -12,6 +12,11 @@ describe(`TsccSpec`, () => {
 			expect(spec.getOrderedModuleSpecs().length).toBe(1);
 		});
 
+		test(`loads spec from a directory specified via specFile key`, () => {
+			const spec = TsccSpec.loadSpec({ specFile: testSpecDir });
+			expect(spec.getOrderedModuleSpecs().length).toBe(1);
+		});
+
 		test(`loads spec by searching on ancestor directories starting from CWD`, () => {
 			const done = mockCurrentWorkingDirectory(path.join(testSpecDir, 'nested_directory'));
 

--- a/packages/tscc-spec/test/TsccSpec.ts
+++ b/packages/tscc-spec/test/TsccSpec.ts
@@ -50,7 +50,7 @@ describe(`TsccSpec`, () => {
 				errorThrown = e;
 			}
 			expect(errorThrown).toBeTruthy();
-			expect(errorThrown.message).toBe(`No spec file was found from directory /`);
+			expect(errorThrown.message).toBe(`No spec file was found from /.`);
 		});
 
 		const invalidSpecJSONPath = path.join(__dirname, 'sample/invalid_json.json');

--- a/packages/tscc-spec/test/TsccSpec.ts
+++ b/packages/tscc-spec/test/TsccSpec.ts
@@ -13,7 +13,7 @@ describe(`TsccSpec`, () => {
 		});
 
 		test(`loads spec from a directory specified via specFile key`, () => {
-			const spec = TsccSpec.loadSpec({ specFile: testSpecDir });
+			const spec = TsccSpec.loadSpec({specFile: testSpecDir});
 			expect(spec.getOrderedModuleSpecs().length).toBe(1);
 		});
 
@@ -40,6 +40,17 @@ describe(`TsccSpec`, () => {
 			// a not found error.
 
 			done();
+		});
+
+		test(`when it cannot find a spec file at a path referenced via specFile key, throws an error with meaningful error message`, () => {
+			let errorThrown: Error;
+			try {
+				TsccSpec.loadSpec({specFile: '/'});
+			} catch (e) {
+				errorThrown = e;
+			}
+			expect(errorThrown).toBeTruthy();
+			expect(errorThrown.message).toBe(`No spec file was found from directory /`);
 		});
 
 		const invalidSpecJSONPath = path.join(__dirname, 'sample/invalid_json.json');

--- a/packages/tscc-spec/test/TsccSpec.ts
+++ b/packages/tscc-spec/test/TsccSpec.ts
@@ -1,9 +1,28 @@
 ///<reference types="jest"/>
 import TsccSpec, {TsccSpecError} from '../src/TsccSpec';
 import path = require('path');
+import process = require('process');
 
 describe(`TsccSpec`, () => {
 	describe(`loadSpec`, () => {
+		const testSpecDir = path.join(__dirname, 'sample');
+		const testSpecPath = path.join(testSpecDir, 'tscc.spec.json');
+
+		test(`loads spec file from a specified directory`, () => {
+			const spec = TsccSpec.loadSpec(testSpecDir);
+			expect(spec.getOrderedModuleSpecs().length).toBe(1);
+		});
+
+		test(`loads spec by searching on ancestor directories starting from CWD`, () => {
+			const spy = jest.spyOn(process, 'cwd');
+			spy.mockReturnValue(path.join(testSpecDir, 'nested_directory'));
+
+			const spec = TsccSpec.loadSpec(undefined);
+			expect(spec.getOrderedModuleSpecs().length).toBe(1);
+
+			spy.mockRestore();
+		});
+
 		const invalidSpecJSONPath = path.join(__dirname, 'sample/invalid_json.json');
 
 		test(`throws when the spec file content is an invalid JSON.`, () => {

--- a/packages/tscc-spec/test/sample/tscc.spec.json
+++ b/packages/tscc-spec/test/sample/tscc.spec.json
@@ -1,0 +1,5 @@
+{
+	"modules": {
+		"out": "index.ts"
+	}
+}

--- a/packages/tscc/src/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/src/spec/TsccSpecWithTS.ts
@@ -1,7 +1,6 @@
 import {IInputTsccSpecJSON, ITsccSpecJSON, primitives, TsccSpec, TsccSpecError} from '@tscc/tscc-spec';
 import * as ts from 'typescript';
 import ITsccSpecWithTS from './ITsccSpecWithTS';
-import fs = require('fs');
 import path = require('path');
 
 export class TsError extends Error {
@@ -34,7 +33,7 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 	}
 	// compilerOptions is a JSON object in the form of tsconfig.json's compilerOption value.
 	// Its value will override compiler options.
-	static loadTsConfigFromPath(tsConfigPath: string, specRoot: string, compilerOptions?: object) {
+	static loadTsConfigFromPath(tsConfigPath: string, specRoot?: string, compilerOptions?: object) {
 		const configFileName = TsccSpecWithTS.findConfigFileAndThrow(tsConfigPath, specRoot);
 		let options: ts.CompilerOptions = {}, errors: ts.Diagnostic[];
 		if (compilerOptions) {
@@ -51,7 +50,7 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		const configFileName =
 			TsccSpecWithTS.resolveSpecFile(searchPath, 'tsconfig.json', defaultLocation);
 		if (configFileName === undefined) {
-			throw new TsccSpecError(`Cannot find tsconfig at ${searchPath}.`)
+			throw new TsccSpecError(`Cannot find tsconfig at ${TsccSpecWithTS.toDisplayedPath(searchPath)}.`)
 		}
 		return configFileName;
 	}

--- a/packages/tscc/src/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/src/spec/TsccSpecWithTS.ts
@@ -29,18 +29,13 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		// I think this is a more reasonable behavior, since many users will just put spec.json and
 		// tsconfig.json at the same directory, they will otherwise have to provide the same information
 		// twice, once for tscc and once for tsc.
-		const configFileName = TsccSpecWithTS.findConfigFileAndThrow(options.project || specRoot);
+		const configFileName = TsccSpecWithTS.findConfigFileAndThrow(options.project, specRoot);
 		return TsccSpecWithTS.loadTsConfigFromResolvedPath(configFileName, options);
 	}
 	// compilerOptions is a JSON object in the form of tsconfig.json's compilerOption value.
 	// Its value will override compiler options.
-	static loadTsConfigFromPath(tsConfigPath: string, compilerOptions?: object) {
-		if (!fs.existsSync(tsConfigPath)) {
-			throw new TsccSpecError(`No file or directory found at ${tsConfigPath}`);
-		}
-		const configFileName = fs.lstatSync(tsConfigPath).isFile() ?
-			path.resolve(tsConfigPath) :
-			TsccSpecWithTS.findConfigFileAndThrow(tsConfigPath);
+	static loadTsConfigFromPath(tsConfigPath: string, specRoot: string, compilerOptions?: object) {
+		const configFileName = TsccSpecWithTS.findConfigFileAndThrow(tsConfigPath, specRoot);
 		let options: ts.CompilerOptions = {}, errors: ts.Diagnostic[];
 		if (compilerOptions) {
 			({options, errors} = ts.convertCompilerOptionsFromJson(
@@ -52,10 +47,11 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		}
 		return TsccSpecWithTS.loadTsConfigFromResolvedPath(configFileName, options);
 	}
-	private static findConfigFileAndThrow(searchLocation: string) {
-		const configFileName = ts.findConfigFile(searchLocation, fs.existsSync);
+	private static findConfigFileAndThrow(searchPath: string, defaultLocation: string) {
+		const configFileName =
+			TsccSpecWithTS.resolveSpecFile(searchPath, 'tsconfig.json', defaultLocation);
 		if (configFileName === undefined) {
-			throw new TsccSpecError(`Cannot find tsconfig.json at ${searchLocation}.`)
+			throw new TsccSpecError(`Cannot find tsconfig at ${searchPath}.`)
 		}
 		return configFileName;
 	}
@@ -78,7 +74,7 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		let specRoot = path.dirname(tsccSpecJSONPath);
 		let {projectRoot, parsedConfig} = Array.isArray(tsConfigPathOrTsArgs) ?
 			TsccSpecWithTS.loadTsConfigFromArgs(tsConfigPathOrTsArgs, specRoot, onTsccWarning) :
-			TsccSpecWithTS.loadTsConfigFromPath(tsConfigPathOrTsArgs || specRoot, compilerOptionsOverride);
+			TsccSpecWithTS.loadTsConfigFromPath(tsConfigPathOrTsArgs, specRoot, compilerOptionsOverride);
 
 		TsccSpecWithTS.pruneCompilerOptions(parsedConfig.options, onTsccWarning);
 		return new TsccSpecWithTS(tsccSpecJSON, tsccSpecJSONPath, parsedConfig, projectRoot);

--- a/packages/tscc/test/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/test/spec/TsccSpecWithTS.ts
@@ -4,18 +4,41 @@ import * as ts from 'typescript';
 import path = require('path');
 
 describe(`TsccSpecWithTS`, () => {
-	describe(`loadTsCOnfigFromArgs`, ()=> {
-
+	describe(`loadTsConfigFromArgs`, () => {
+		test(`searches tsconfig from a directory provided by --project flag`,  () => {
+			const projectInNestedDirectory = path.join(__dirname, 'sample/nested_directory');
+			const {projectRoot, parsedConfig} = TsccSpecWithTS.loadTsConfigFromArgs(
+				['--project', projectInNestedDirectory],
+				undefined,
+				()=>{}
+			);
+			expect(projectRoot).toBe(projectInNestedDirectory);
+			expect(parsedConfig.options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeJs);
+		});
 	})
 	describe(`loadTsConfigFromPath`, () => {
+		test(`searches tsconfig from ancestor directories of specFile when tsconfig path is undefined`, () => {
+			const directoryNestedInProject = path.join(
+				__dirname,
+				'sample/nested_directory/nested_nested_directory'
+			);
+			const {projectRoot, parsedConfig} = TsccSpecWithTS.loadTsConfigFromPath(
+				undefined,
+				directoryNestedInProject
+			);
+			expect(projectRoot).toBe(path.dirname(directoryNestedInProject));
+			expect(parsedConfig.options.downlevelIteration).toBe(true);
+		});
 		test(`merges compilerOptions override provided as a second argument`, () => {
-			const {parsedConfig} = TsccSpecWithTS.loadTsConfigFromPath(
+			const {projectRoot, parsedConfig} = TsccSpecWithTS.loadTsConfigFromPath(
 				path.join(__dirname, 'sample/tsconfig.1.json'),
+				'/',
 				{
 					target: 'ES2016',
 					downlevelIteration: false
 				}
 			);
+			expect(projectRoot).toBe(path.join(__dirname, 'sample'));
 			expect(parsedConfig.options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeJs);
 			expect(parsedConfig.options.target).toBe(ts.ScriptTarget.ES2016);
 			expect(parsedConfig.options.downlevelIteration).toBe(false);

--- a/packages/tscc/test/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/test/spec/TsccSpecWithTS.ts
@@ -5,12 +5,12 @@ import path = require('path');
 
 describe(`TsccSpecWithTS`, () => {
 	describe(`loadTsConfigFromArgs`, () => {
-		test(`searches tsconfig from a directory provided by --project flag`,  () => {
+		test(`searches tsconfig from a directory provided by --project flag`, () => {
 			const projectInNestedDirectory = path.join(__dirname, 'sample/nested_directory');
 			const {projectRoot, parsedConfig} = TsccSpecWithTS.loadTsConfigFromArgs(
 				['--project', projectInNestedDirectory],
 				undefined,
-				()=>{}
+				() => {}
 			);
 			expect(projectRoot).toBe(projectInNestedDirectory);
 			expect(parsedConfig.options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeJs);

--- a/packages/tscc/test/spec/sample/nested_directory/tsconfig.json
+++ b/packages/tscc/test/spec/sample/nested_directory/tsconfig.json
@@ -1,5 +1,5 @@
 {
-
+	"compilerOptions": {
 		"target": "ES5",
 		"moduleResolution": "Node",
 		"downlevelIteration": true

--- a/packages/tscc/test/spec/sample/nested_directory/tsconfig.json
+++ b/packages/tscc/test/spec/sample/nested_directory/tsconfig.json
@@ -1,0 +1,7 @@
+{
+
+		"target": "ES5",
+		"moduleResolution": "Node",
+		"downlevelIteration": true
+	}
+}


### PR DESCRIPTION
…e Typescript CLI compiler.

 1. if --project argument is supplied,
   1-1. If it is a file, use it.
   1-2. If it is a directory, use directory/tsconfig.json.
   1-3. If it is not a file nor a directory, throw an error.
 2. If it is not supplied (and file arguments are not supplied which is always the case for tscc),
    it calls ts.findConfigFile to search for tsconfig.json from the current working directory.

We apply the same logic for our `--spec` key and `--project` key, with a modification that cwd is replaced
with the spec file's directory in case 2.

Implements #64 