### PR TITLE
Require global `goog` namespace access to use import `goog:goog`

### DIFF
--- a/packages/rollup-plugin-tscc/src/goog_shim_mixin.ts
+++ b/packages/rollup-plugin-tscc/src/goog_shim_mixin.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Provides a mixin for Rollup plugins that loads shim files for default libraries.
+ * These are goog.goog and goog.reflect, which are always included if one is bundling with
+ * @tscc/tscc.
+ */
+import {Plugin} from 'rollup';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SHIM_ROOT = path.resolve(__dirname, "../third_party/closure_library");
+
+const things = new Map([
+	["goog:goog", fs.readFileSync(path.join(SHIM_ROOT, "goog_shim.js"), "utf8")],
+	["goog:goog.reflect", fs.readFileSync(path.join(SHIM_ROOT, "reflect_shim.js"), "utf8")]
+]);
+
+// Rollup convention, see https://rollupjs.org/guide/en/#conventions
+const PREFIX = "\0tscc\0";
+
+export function googShimMixin(plugin: Plugin): Plugin {
+	const {resolveId, load} = plugin;
+	plugin.resolveId = function (id, importer) {
+		if (things.has(id)) return PREFIX + id;
+		return Reflect.apply(resolveId!, this, arguments);
+	}
+	plugin.load = function (id) {
+		if (id.startsWith(PREFIX)) return things.get(id.substring(PREFIX.length));
+		return Reflect.apply(load!, this, arguments);
+	}
+	return plugin;
+}

--- a/packages/rollup-plugin-tscc/src/merge_chunks.ts
+++ b/packages/rollup-plugin-tscc/src/merge_chunks.ts
@@ -2,6 +2,7 @@ import * as rollup from 'rollup';
 import MultiMap from './MultiMap';
 import path = require('path');
 import upath = require('upath');
+import {googShimMixin} from './goog_shim_mixin';
 
 export default async function mergeChunks(
 	entry: string,
@@ -108,7 +109,7 @@ class ChunkMerger {
 			throw new ChunkMergeError(`Unexpected module in output chunk: ${id}`);
 		};
 		const name = "tscc-merger";
-		return {name, resolveId, load};
+		return googShimMixin({name, resolveId, load});
 	}
 	private resolveGlobal(id: string): string {
 		if (this.resolveGlobalForMainBuild(id)) return this.globals![id]!;

--- a/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
+++ b/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
@@ -55,6 +55,66 @@ exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json 2`] 
 "
 `;
 
+exports[`Golden Tests: goog-shim/tscc.spec.json 1`] = `
+"var generated_entry = (function (exports) {
+	'use strict';
+
+	/**
+	 * @fileoverview Hand-modified shim file for Closure Library \`goog/goog.js\`. References to the
+	 * global \`goog\` variables have been removed.
+	 */
+	const global =  self;
+
+	let DEBUG = true;
+
+	function isDebugging() {
+		return DEBUG;
+	}
+
+	{
+		console.log(\\"Debugging\\");
+	}
+
+	var _ = {
+		__proto__: null,
+		g: global,
+		i: isDebugging
+	};
+
+	exports.$0 = _;
+	exports.isDebugging = isDebugging;
+
+	return exports;
+
+}({}));
+"
+`;
+
+exports[`Golden Tests: goog-shim/tscc.spec.json 2`] = `
+"(function (_) {
+	'use strict';
+
+	/**
+	 * @fileoverview Hand-modified shim file for Closure Library \`goog/reflect.js\`. References to the
+	 * global \`goog\` variables have been removed.
+	 */
+
+	function objectProperty(prop, object) {
+		return prop;
+	}
+
+	var dictionary = {
+		\\"key\\": \\"value\\"
+	};
+
+	if ( _.g.name === objectProperty(\\"key\\")) {
+		console.log(dictionary[_.g.name]);
+	}
+
+}(generated_entry.$0));
+"
+`;
+
 exports[`Golden Tests: many-module-build/tscc.spec.json 1`] = `
 "var generated_entry = (function (exports) {
 	'use strict';

--- a/packages/rollup-plugin-tscc/test/sample/goog-shim/dependent.js
+++ b/packages/rollup-plugin-tscc/test/sample/goog-shim/dependent.js
@@ -1,0 +1,15 @@
+import * as entry from './entry';
+
+import * as goog from 'goog:goog';
+
+// This module is only used in "dependent" module, so the corresponding shim file's content should
+// only be included in the "dependent" chunk.
+import * as googReflect from 'goog:goog.reflect';
+
+var dictionary = {
+	"key": "value"
+};
+
+if (entry.isDebugging() && goog.global.name === googReflect.objectProperty("key", dictionary)) {
+	console.log(dictionary[goog.global.name]);
+};

--- a/packages/rollup-plugin-tscc/test/sample/goog-shim/entry.js
+++ b/packages/rollup-plugin-tscc/test/sample/goog-shim/entry.js
@@ -1,0 +1,9 @@
+import * as goog from 'goog:goog';
+
+export function isDebugging() {
+	return goog.DEBUG;
+}
+
+if (isDebugging()) {
+	console.log("Debugging");
+}

--- a/packages/rollup-plugin-tscc/test/sample/goog-shim/tscc.spec.json
+++ b/packages/rollup-plugin-tscc/test/sample/goog-shim/tscc.spec.json
@@ -1,0 +1,15 @@
+{
+	"modules": {
+		"entry": "./entry.js",
+		"dependent": {
+			"entry": "./dependent.js",
+			"dependencies": [
+				"entry"
+			]
+		}
+	},
+	"prefix": {
+		"rollup": "./golden/generated_",
+		"cc": "."
+	}
+}

--- a/packages/rollup-plugin-tscc/third_party/closure_library/README.md
+++ b/packages/rollup-plugin-tscc/third_party/closure_library/README.md
@@ -1,0 +1,6 @@
+Original source: https://github.com/google/closure-library
+License: Apache 2.0
+Description:
+When `rollup-plugin-tscc` bundle files that reference `goog:goog.goog` or `goog:goog.reflect`, the
+plugin will link such modules to files contained in this directory to enable correct runtime
+behavior.

--- a/packages/rollup-plugin-tscc/third_party/closure_library/goog_shim.js
+++ b/packages/rollup-plugin-tscc/third_party/closure_library/goog_shim.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Hand-modified shim file for Closure Library `goog/goog.js`. References to the
+ * global `goog` variables have been removed.
+ */
+export const global = this || self;
+
+export function define() {}
+
+export let DEBUG = true;
+
+export function typeOf(value) {
+	var s = typeof value;
+	if (s != 'object') return s;
+	if (!value) return 'null';
+	if (Array.isArray(value)) return 'array';
+	return s;
+};
+export function isArrayLike(val) {
+	var type = typeOf(val);
+	return type == 'array' || type == 'object' && typeof val.length == 'number';
+}
+export function isObject(val) {
+	var type = typeof val;
+	return type == 'object' && val != null || type == 'function';
+}
+export function getCssName(className, opt_modifier) {
+	return className;
+}
+export function getMsg(str, opt_values, opt_options) {
+	if (opt_options && opt_options.html) {
+		// Note that '&' is not replaced because the translation can contain HTML
+		// entities.
+		str = str.replace(/</g, '&lt;');
+	}
+	if (opt_options && opt_options.unescapeHtmlEntities) {
+		// Note that "&amp;" must be the last to avoid "creating" new entities.
+		str = str.replace(/&lt;/g, '<')
+			.replace(/&gt;/g, '>')
+			.replace(/&apos;/g, '\'')
+			.replace(/&quot;/g, '"')
+			.replace(/&amp;/g, '&');
+	}
+	if (opt_values) {
+		str = str.replace(/\{\$([^}]+)}/g, function (match, key) {
+			return (opt_values != null && key in opt_values) ? opt_values[key] :
+				match;
+		});
+	}
+	return str;
+}
+export function exportSymbol(publicPath, object, objectToExportTo) {
+	var parts = publicPath.split('.');
+	var cur = objectToExportTo || global;
+	for (var part; parts.length && (part = parts.shift());) {
+		if (!parts.length && object !== undefined) {
+			cur[part] = object;
+		} else if (cur[part] && cur[part] !== Object.prototype[part]) {
+			cur = cur[part];
+		} else {
+			cur = cur[part] = {};
+		}
+	}
+}
+export function exportProperty(object, publicName, symbol) {
+	object[publicName] = symbol;
+}

--- a/packages/rollup-plugin-tscc/third_party/closure_library/reflect_shim.js
+++ b/packages/rollup-plugin-tscc/third_party/closure_library/reflect_shim.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Hand-modified shim file for Closure Library `goog/reflect.js`. References to the
+ * global `goog` variables have been removed.
+ */
+
+export function object(type, object) {
+	return object;
+}
+
+export function objectProperty(prop, object) {
+	return prop;
+}
+
+export function sinkValue(x) {
+	sinkValue[' '](x);
+	return x;
+}
+sinkValue[' '] = function () {};
+
+export function canAccessProperty(obj, prop) {
+	try {
+		sinkValue(obj[prop]);
+		return true;
+	} catch (e) {}
+	return false;
+}
+
+export function cache(cacheObj, key, valueFn, opt_keyFn) {
+	const storedKey = opt_keyFn ? opt_keyFn(key) : key;
+
+	if (Object.prototype.hasOwnProperty.call(cacheObj, storedKey)) {
+		return cacheObj[storedKey];
+	}
+
+	return (cacheObj[storedKey] = valueFn(key));
+};

--- a/packages/tscc/src/transformer/decorator_property_transformer.ts
+++ b/packages/tscc/src/transformer/decorator_property_transformer.ts
@@ -43,7 +43,7 @@ class DecoratorTransformer extends TsHelperTransformer {
 	}
 	private counter = 1;
 
-	protected onHelperCall(node: ts.CallExpression, googReflectImport:ts.Identifier) {
+	protected onHelperCall(node: ts.CallExpression, googReflectImport: ts.Identifier) {
 		// Found a candidate. Decorator helper call signature:
 		// __decorate([decoratorsArray], <target>, <propertyName>, <desc>)
 		// Note that class decorator only has 2 arguments.
@@ -54,14 +54,14 @@ class DecoratorTransformer extends TsHelperTransformer {
 		// Create goog.reflect.objectProperty
 		const target = node.arguments[1];
 		const googReflectObjectProperty = ts.setTextRange(
-			ts.createCall(
-				ts.createPropertyAccess(
+			this.factory.createCallExpression(
+				this.factory.createPropertyAccessExpression(
 					googReflectImport,
-					ts.createIdentifier('objectProperty')
+					this.factory.createIdentifier('objectProperty')
 				),
 				undefined,
 				[
-					ts.createStringLiteral(propName),
+					this.factory.createStringLiteral(propName),
 					ts.getMutableClone(target)
 				]
 			),
@@ -74,33 +74,33 @@ class DecoratorTransformer extends TsHelperTransformer {
 		const caller = node.expression;
 		const decorateArgs = node.arguments.slice();
 		decorateArgs.splice(2, 1, googReflectObjectProperty);
-		const newCallExpression = ts.createCall(caller, undefined, decorateArgs);
-		const globalAssignment = ts.createBinary(
-			ts.createElementAccess(
-				ts.createIdentifier("self"),
-				ts.createStringLiteral(this.getId())
+		const newCallExpression = this.factory.createCallExpression(caller, undefined, decorateArgs);
+		const globalAssignment = this.factory.createBinaryExpression(
+			this.factory.createElementAccessExpression(
+				this.factory.createIdentifier("self"),
+				this.factory.createStringLiteral(this.getId())
 			),
-			ts.createToken(ts.SyntaxKind.FirstAssignment),
-			ts.createPropertyAccess(
-				ts.createParen(ts.getMutableClone(target)),
-				ts.createIdentifier(propName)
+			this.factory.createToken(ts.SyntaxKind.FirstAssignment),
+			this.factory.createPropertyAccessExpression(
+				this.factory.createParenthesizedExpression(ts.getMutableClone(target)),
+				this.factory.createIdentifier(propName)
 			)
 		);
 		this.tempGlobalAssignments.push(
 			ts.setEmitFlags(
-				ts.createExpressionStatement(globalAssignment),
+				this.factory.createExpressionStatement(globalAssignment),
 				ts.EmitFlags.NoSourceMap | ts.EmitFlags.NoTokenSourceMaps | ts.EmitFlags.NoNestedSourceMaps
 			)
 		);
 		return newCallExpression;
 	}
 
-	protected combineStatements(stmts:ts.Statement[], googReflectImport:ts.Identifier) {
+	protected combineStatements(stmts: ts.Statement[], googReflectImport: ts.Identifier) {
 		super.combineStatements(stmts, googReflectImport);
 		stmts.push(
-			ts.createExpressionStatement(ts.createStringLiteral("__tscc_export_start__")),
-			ts.createBlock(this.tempGlobalAssignments),
-			ts.createExpressionStatement(ts.createStringLiteral('__tscc_export_end__'))
+			this.factory.createExpressionStatement(this.factory.createStringLiteral("__tscc_export_start__")),
+			this.factory.createBlock(this.tempGlobalAssignments),
+			this.factory.createExpressionStatement(this.factory.createStringLiteral('__tscc_export_end__'))
 		);
 		return stmts;
 	}

--- a/packages/tscc/src/transformer/dts_requiretype_transformer.ts
+++ b/packages/tscc/src/transformer/dts_requiretype_transformer.ts
@@ -22,9 +22,10 @@ import * as ts from 'typescript';
 import ITsccSpecWithTS from '../spec/ITsccSpecWithTS';
 import {TsickleHost} from 'tsickle';
 import {moduleNameAsIdentifier} from 'tsickle/out/src/annotator_host';
-import {namespaceToQualifiedName, isGoogRequireLikeStatement} from './transformer_utils';
+import {isGoogRequireLikeStatement, topLevelStatementTransformerFactory} from './transformer_utils';
 import {escapedGoogNameIsDts, unescapeGoogAdmissibleName} from '../shared/escape_goog_identifier';
 import path = require('path');
+
 /**
  * This is a transformer run after ts transformation, before googmodule transformation.
  *
@@ -35,64 +36,42 @@ import path = require('path');
 export default function dtsRequireTypeTransformer(spec: ITsccSpecWithTS, tsickleHost: TsickleHost)
 	: (context: ts.TransformationContext) => ts.Transformer<ts.SourceFile> {
 	const externalModuleNames = spec.getExternalModuleNames();
-	return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
-		return (sf: ts.SourceFile): ts.SourceFile => {
-			function maybeExternalModuleRequireType(
-				original: ts.Statement, importedUrl: string, newIdent: ts.Identifier
-			) {
-				const setOriginalNode = (range: ts.Statement) => {
-					return ts.setOriginalNode(ts.setTextRange(range, original), original);
-				}
-				// We are only interested in `requireType`ing .d.ts files.
-				if (!escapedGoogNameIsDts(importedUrl)) return null;
-				// If imported url is external module, no need to handle it further.
-				if (externalModuleNames.includes(importedUrl)) return null;
-				// origUrl will be a file path relative to the ts project root.
-				let origUrl = unescapeGoogAdmissibleName(importedUrl);
-				let absoluteOrigUrl = path.resolve(spec.getTSRoot(), origUrl);
-				// We must figure out on what namespace the extern for this module is defined.
-				// See tsickle/src/externs.js for precise logic. In our case, goog.requireType(....d.ts)
-				// will be emitted for "module .d.ts", in which case a mangled name derived from a
-				// .d.ts file's path is used. See how `moduleNamespace`, `rootNamespace` is constructed
-				// in tsickle/src/externs.js.
-				// This relies on the heuristic of tsickle, so must be carefully validated whenever tsickle updates.
-				let mangledNamespace = moduleNameAsIdentifier(tsickleHost, absoluteOrigUrl);
-				if (newIdent.escapedText === mangledNamespace) {
-					// Name of the introduced identifier coincides with the global identifier,
-					// no need to emit things.
-					return setOriginalNode(ts.createEmptyStatement());
-				}
-				// Convert `const importedName = goog.requireType("module d.ts")` to:
-				// `const importedName = mangledNamespace;`
-				return setOriginalNode(ts.createVariableStatement(
-					undefined,
-					ts.createVariableDeclarationList(
-						[
-							ts.createVariableDeclaration(
-								newIdent,
-								undefined,
-								namespaceToQualifiedName(mangledNamespace)
-							)
-						],
-						tsickleHost.es5Mode ? undefined : ts.NodeFlags.Const
-					)
-				));
-			}
-			function visitTopLevelStatement(statements: ts.Statement[], sf: ts.SourceFile, node: ts.Statement) {
-				lookupExternalModuleRequire: {
-					let _ = isGoogRequireLikeStatement(node, "requireType");
-					if (!_) break lookupExternalModuleRequire;
-					let {importedUrl, newIdent} = _;
-					const requireType = maybeExternalModuleRequireType(node, importedUrl, newIdent);
-					if (!requireType) break lookupExternalModuleRequire;
-					statements.push(requireType);
-					return;
-				}
-				statements.push(node);
-			}
-			const stmts: ts.Statement[] = [];
-			for (const stmt of sf.statements) visitTopLevelStatement(stmts, sf, stmt);
-			return ts.updateSourceFileNode(sf, ts.setTextRange(ts.createNodeArray(stmts), sf.statements));
+
+	return topLevelStatementTransformerFactory((node, fh) => {
+		let _ = isGoogRequireLikeStatement(node, "requireType");
+		if (!_) return node;
+		let {importedUrl, newIdent} = _;
+
+		// We are only interested in `requireType`ing .d.ts files.
+		if (!escapedGoogNameIsDts(importedUrl)) return node;
+		// If imported url is external module, no need to handle it further.
+		if (externalModuleNames.includes(importedUrl)) return node;
+		// origUrl will be a file path relative to the ts project root.
+		let origUrl = unescapeGoogAdmissibleName(importedUrl);
+		let absoluteOrigUrl = path.resolve(spec.getTSRoot(), origUrl);
+		// We must figure out on what namespace the extern for this module is defined.
+		// See tsickle/src/externs.js for precise logic. In our case, goog.requireType(....d.ts)
+		// will be emitted for "module .d.ts", in which case a mangled name derived from a
+		// .d.ts file's path is used. See how `moduleNamespace`, `rootNamespace` is constructed
+		// in tsickle/src/externs.js.
+		// This relies on the heuristic of tsickle, so must be carefully validated whenever tsickle updates.
+		let mangledNamespace = moduleNameAsIdentifier(tsickleHost, absoluteOrigUrl);
+		if (newIdent.escapedText === mangledNamespace) {
+			// Name of the introduced identifier coincides with the global identifier,
+			// no need to emit things.
+			return setOriginalNode(fh.factory.createEmptyStatement(), node);
 		}
-	}
+		// Convert `const importedName = goog.requireType("module d.ts")` to:
+		// `const importedName = mangledNamespace;`
+		return setOriginalNode(
+			fh.createVariableAssignment(
+				newIdent, fh.namespaceToQualifiedName(mangledNamespace), !tsickleHost.es5Mode
+			),
+			node
+		);
+	});
+}
+
+function setOriginalNode<T extends ts.Node>(range: T, node: ts.Statement): T {
+	return ts.setOriginalNode<T>(ts.setTextRange(range, node), node);
 }

--- a/packages/tscc/src/transformer/goog_namespace_transformer.ts
+++ b/packages/tscc/src/transformer/goog_namespace_transformer.ts
@@ -1,0 +1,21 @@
+import {isVariableRequireStatement, isGoogRequireLikeStatement, topLevelStatementTransformerFactory} from './transformer_utils';
+
+export const googNamespaceTransformer = topLevelStatementTransformerFactory((stmt, fh) => {
+	// Before googmodule transformer of tsickle, import statements we are looking for looks like
+	// var goog = require('goog:goog').
+	let _ = isVariableRequireStatement(stmt);
+	if (_) {
+		let {importedUrl, newIdent} = _;
+		if (importedUrl === "goog:goog" && newIdent.text === "goog") {
+			return fh.factory.createNotEmittedStatement(stmt);
+		}
+	} else {
+		_ = isGoogRequireLikeStatement(stmt, "requireType");
+		if (_) {
+			let {importedUrl, newIdent} = _;
+			if (importedUrl === "goog") {
+				return fh.createVariableAssignment(newIdent, fh.factory.createIdentifier("goog"));
+			}
+		}
+	}
+});

--- a/packages/tscc/src/transformer/rest_property_transformer.ts
+++ b/packages/tscc/src/transformer/rest_property_transformer.ts
@@ -13,7 +13,7 @@ export default function decoratorPropertyTransformer(tsickleHost: TsickleHost):
 
 class RestHelperTransformer extends TsHelperTransformer {
 	protected HELPER_NAME = "__rest";
-	/**	
+	/**
 	 * Rest helper call signature:
 	 * __rest(<target>, [propertiesArray])
 	 */
@@ -29,18 +29,18 @@ class RestHelperTransformer extends TsHelperTransformer {
 		// typeof _p === 'symbol' ? _c : _c + ""
 		// ```
 		const convertedArray = ts.setTextRange(
-			ts.createArrayLiteral(
+			this.factory.createArrayLiteralExpression(
 				propertiesArray.elements.map((propNameLiteral: ts.Expression) => {
 					if (!ts.isStringLiteral(propNameLiteral)) return propNameLiteral;
 					const googReflectObjectProperty = ts.setTextRange(
-						ts.createCall(
-							ts.createPropertyAccess(
+						this.factory.createCallExpression(
+							this.factory.createPropertyAccessExpression(
 								googReflectImport,
-								ts.createIdentifier('objectProperty')
+								this.factory.createIdentifier('objectProperty')
 							),
 							undefined,
 							[
-								ts.createStringLiteral(propNameLiteral.text),
+								this.factory.createStringLiteral(propNameLiteral.text),
 								ts.getMutableClone(target)
 							]
 						),
@@ -53,7 +53,7 @@ class RestHelperTransformer extends TsHelperTransformer {
 		);
 		const restArgs = node.arguments.slice();
 		restArgs.splice(1, 1, convertedArray);
-		const newCallExpression = ts.createCall(caller, undefined, restArgs);
+		const newCallExpression = this.factory.createCallExpression(caller, undefined, restArgs);
 		return newCallExpression;
 	}
 }

--- a/packages/tscc/src/tscc.ts
+++ b/packages/tscc/src/tscc.ts
@@ -30,6 +30,7 @@ import fsExtra = require('fs-extra');
 import vfs = require('vinyl-fs');
 import upath = require('upath');
 import chalk = require('chalk');
+import {googNamespaceTransformer} from './transformer/goog_namespace_transformer';
 
 
 export const TEMP_DIR = ".tscc_temp";
@@ -140,6 +141,7 @@ export default async function tscc(
 		applyPatches();
 		result = tsickle.emit(program, transformerHost, writeFile, undefined, undefined, false, {
 			afterTs: [
+				googNamespaceTransformer,
 				dtsRequireTypeTransformer(tsccSpec, transformerHost),
 				decoratorPropertyTransformer(transformerHost),
 				restPropertyTransformer(transformerHost)

--- a/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
+++ b/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
@@ -137,3 +137,20 @@ exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_10_unsafe_modu
 "console.log(unsafeModuleName.variableNameThatShouldntBeMangled.propertyNameThatShouldntBeMangled);
 "
 `;
+
+exports[`tscc e2e case_11_referencing_goog: case_11_referencing_goog 1`] = `
+Array [
+  "dependent.js",
+  "entry.js",
+]
+`;
+
+exports[`tscc e2e case_11_referencing_goog: case_11_referencing_goog/dependent.js 1`] = `
+"var b={key:\\"value\\"};\\"key\\"===a[\\" \\"]&&console.log(b[a[\\" \\"]]);
+"
+`;
+
+exports[`tscc e2e case_11_referencing_goog: case_11_referencing_goog/entry.js 1`] = `
+"var goog=goog||{},a=this||self;console.log(\\"Debugging\\");
+"
+`;

--- a/packages/tscc/test/e2e/sample/case_11_referencing_goog/dependent.ts
+++ b/packages/tscc/test/e2e/sample/case_11_referencing_goog/dependent.ts
@@ -1,0 +1,19 @@
+///<reference path="../../../../third_party/closure_library/base.d.ts"/>
+///<reference path="../../../../third_party/closure_library/reflect.d.ts"/>
+import * as entry from './entry';
+import * as goog from 'goog:goog';
+
+// This module is only used in "dependent" module, so the corresponding shim file's content should
+// only be included in the "dependent" chunk.
+import * as googReflect from 'goog:goog.reflect';
+
+
+var name = ' ';
+
+var dictionary = {
+	key: "value"
+};
+
+if (entry.isDebugging() && goog.global[name] === googReflect.objectProperty("key", dictionary)) {
+	console.log(dictionary[goog.global[name]]);
+};

--- a/packages/tscc/test/e2e/sample/case_11_referencing_goog/entry.ts
+++ b/packages/tscc/test/e2e/sample/case_11_referencing_goog/entry.ts
@@ -1,0 +1,10 @@
+///<reference path="../../../../third_party/closure_library/base.d.ts"/>
+import * as goog from 'goog:goog';
+
+export function isDebugging() {
+	return goog.DEBUG;
+}
+
+if (isDebugging()) {
+	console.log("Debugging");
+}

--- a/packages/tscc/test/e2e/sample/case_11_referencing_goog/tscc.spec.json
+++ b/packages/tscc/test/e2e/sample/case_11_referencing_goog/tscc.spec.json
@@ -1,0 +1,15 @@
+{
+	"modules": {
+		"entry": "./entry.ts",
+		"dependent": {
+			"entry": "./dependent.ts",
+			"dependencies": [
+				"entry"
+			]
+		}
+	},
+	"prefix": ".tscc_temp/case_11_referencing_goog/",
+	"debug": {
+		"persistArtifacts": true
+	}
+}

--- a/packages/tscc/test/e2e/sample/case_11_referencing_goog/tsconfig.json
+++ b/packages/tscc/test/e2e/sample/case_11_referencing_goog/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.test_files.json",
+	"include": [
+		"./*.ts"
+	]
+}

--- a/packages/tscc/third_party/closure_library/base.d.ts
+++ b/packages/tscc/third_party/closure_library/base.d.ts
@@ -8,6 +8,20 @@
  */
 
 declare namespace goog {
+
+	/**
+	 * Reference to the global object.
+	 * https://www.ecma-international.org/ecma-262/9.0/index.html#sec-global-object
+	 *
+	 * More info on this implementation here:
+	 * https://docs.google.com/document/d/1NAeW4Wk7I7FV0Y2tcUFvQdGMc89k2vdgSXInw8_nvCI/edit
+	 *
+	 * @const
+	 * @suppress {undefinedVars} self won't be referenced unless `this` is falsy.
+	 * @type {!Global}
+	 */
+	const global: typeof globalThis;
+
 	/**
 	 * Handles strings that are intended to be used as CSS class names.
 	 *
@@ -269,3 +283,12 @@ declare namespace goog {
 	function isObject(x: any): x is NonNullable<object> | Function;
 }
 
+// This module name is a tsickle primitive, see `googmodule.ts` of tsickle. Instead of exposing
+// `goog` to the global scope, we let users to write (precisely)
+//
+// import * as goog from 'goog:google3.javascript.closure.goog';
+//
+// to get a handle of a goog namespace.
+declare module "goog:goog" {
+	export = goog;
+}


### PR DESCRIPTION
Previously, one may use `goog` global variable via
triple-slash-referencing base.d.ts file that comes with the @tscc/tscc
package. However, when simiilar build is performed with rollup, rollup
can't know that a module is depend on `goog`. We change the base.d.ts so
that users are required to use import statement to obtain handle of
`goog` variable.

In doing so, a dedicated transformer was implemented to replace such
import statements, and a hand-written shim files were added to the
rollup plugin pacakge.

Also now most node factory functions are replaced to use `ts.Factory`
object available in transformer factory body via context.factory
property. Previous functions were marked as deprecated and this
transition is recommended in deprecation notices.