### PR TITLE
Support emitting ES6 modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
 	"javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
 	"javascript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
 	"typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
-	"typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false
+	"typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
+	"jest.jestCommandLine": "jest"
 }

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ CLI equivalent is `--prefix dist/` (or `--prefix.rollup dev/ --prefix.cc dist/`)
 ```jsonc
     "chunkFormat": "global" /* default */ | "module"
 ```
-It is a value of `"global"` or `"module"` designating the output chunks' format. In case of `"global"`, which is the default behavior if this key isn't specified, output chunks will be a plain Javascript that is suitable for `<script src="">` HTML tag, and cross-chunk references will be done by exposing it to the global scope. In case of `"module"`, output chunks will be [Javascript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), that is suitable for `<script type="module" src="">` tags, and cross-chunk references will be done by `import` and `export` statements. Currently, when `"module"` option is used, `external` option cannot be used – use `"global"` instead.
+It is a value of `"global"` or `"module"` designating the output chunks' format. In case of `"global"`, which is the default behavior if this key isn't specified, output chunks will be plain Javascript that is suitable for `<script src="">` HTML tag, and cross-chunk references will be done by exposing them to the global scope. In case of `"module"`, output chunks will be [Javascript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) which has to be included via `<script type="module" src="">` tags, and cross-chunk references will be done by `import` and `export` statements. Currently, when `"module"` option is used, `external` option cannot be used.
 
 ### `compilerFlags`
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The first argument is either a string representing the path of the spec file or 
 ```js
 tscc({
     /* Contents of spec JSON */
-    specFile: "path_to_spec_file"
+    specFile: "path_to_spec_file.json"
 })
 // To load spec file from the path and override it.
 ```
@@ -148,7 +148,7 @@ module.exports = {
         tscc({
             /* Contents of spec JSON */
             // or,
-            specFile: "path_to_spec_file"
+            specFile: "path_to_spec_file.json"
         })
     ]
 };
@@ -166,6 +166,7 @@ Tscc spec file is a single source of truth of your bundling information. It desc
     modules, /* required */
     external,
     prefix,
+    chunkFormat,
     compilerFlags,
     jsFiles,
     debug
@@ -215,6 +216,13 @@ CLI equivalent is `--external <module_name>:<global_variable_name>`.
 It is a name that will be prepended to the output chunk's name. It is prepended _as is_, which means that if no trailing path separator was provided, it will modify the output file's name. If it is a relative path starting from the current directory ("."), it will be resolved relative to the spec file's location. Otherwise, any relative path will be resolved relative to the current working directory, and absolute paths are used as is.
 
 CLI equivalent is `--prefix dist/` (or `--prefix.rollup dev/ --prefix.cc dist/`).
+
+### `chunkFormat`
+
+```jsonc
+    "chunkFormat": "global" /* default */ | "module"
+```
+It is a value of `"global"` or `"module"` designating the output chunks' format. In case of `"global"`, which is the default behavior if this key isn't specified, output chunks will be a plain Javascript that is suitable for `<script src="">` HTML tag, and cross-chunk references will be done by exposing it to the global scope. In case of `"module"`, output chunks will be [Javascript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), that is suitable for `<script type="module" src="">` tags, and cross-chunk references will be done by `import` and `export` statements. Currently, when `"module"` option is used, `external` option cannot be used – use `"global"` instead.
 
 ### `compilerFlags`
 

--- a/packages/rollup-plugin-tscc/README.md
+++ b/packages/rollup-plugin-tscc/README.md
@@ -1,8 +1,55 @@
 # rollup-plugin-tscc
 
-This is a companion plugin for tscc that enables using bundle information specified in tscc spec file in rollup. This works by creating several iife bundles for each of modules specified in the spec. For multiple modules, it merges non-entry chunks into appropriate entry chunk in order to emulate closure compiler's bundling strategy.
+This is a companion plugin for tscc which lets you perform an isomorphic build with rollup.
+The code splitting strategy of Closure Compiler is rather different from any other bundling tools – it relies on providing an exact set of expected chunks and their interdependencies, whereas most of the available bundlers may create dynamic unnamed chunks. In some cases, the rigid approach of Closure Compiler is more suitable.
 
- - It only supports IIFE bundles - output.format will be overridden to `iife`.
- - It does not expect dynamic imports. As of writing, closure compiler [does not even parse](https://github.com/google/closure-compiler/issues/2770) dynamic import. When closure compiler add supports for it (probably it would provide some interoperability with `goog.loadModule` and such) we may update the plugin.
+This plugin operates solely on the bundling level, and in particular, it does not require Typescript at all, so it can be used in any Javascript projects.
 
-For more detailed deescription, we refer to the [README of the main package](https://github.com/theseanl/tscc).
+## Usage
+
+Feed the output module dependency to `rollup-plugin-tscc` via [tscc spec file](https://github.com/theseanl/tscc#modules),
+[input files](https://rollupjs.org/guide/en/#input), [external](https://rollupjs.org/guide/en/#external), and output file names will be taken care by the plugin.
+
+```js
+// rollup.config.js
+export default {
+    plugins: [
+        output: {
+            dir: '.'
+        }
+        require('@tscc/rollup-plugin-tscc')({
+            /* Contents of spec JSON */
+            modules: {
+                "root-module": "./src/root-entry-file.js",
+                "deferred-chunk-1": {
+                    "entry": "./src/unimportant-feature-entry-file.js",
+                    "dependencies": [
+                        "root-module"
+                    ]
+                }
+            }
+            // or, you can provide the above contents via a separate file.
+            specFile: "path_to_spec_file.json"
+        })
+    ]
+}
+```
+
+Then invoking rollup with the above will produce precisely two files, `root-module.js` and `deferred-chunk-1.js`.
+
+### Chunk format
+
+By specifying `"chunkFormat": "global"` or `"chunkFormat": "module"`, you can designate how the code-splitted output chunks will reference variables and functions in another chunk. `"global"` corresponds to rollup's `"iife"`, and `"module"` corresponds to rollup's `"es"`.
+
+### External modules
+
+Especially in code-splitting builds, it is required to use the spec file's [`external`](https://github.com/theseanl/tscc#external) field instead of the rollup input option's external property, because this information has to be propagated down to the plugin.
+
+### Dynamic imports
+
+It does not support dynamic imports. It is mostly because Closure Compiler doesn't, and this package's goal is to
+provide isomorphic build with closure compiler. Closure Compiler's wiki says it supports pass-through handling of `import()`, but it appears to be broken: https://github.com/google/closure-compiler/issues/3941 – apparently this ECMAScript feature is not widely used within Google. Closure Compiler's focus on _sequential_ nature of JS, which makes it extremely robust, doesn't seem to be a good fit with dynamic imports.
+
+---
+
+For more detailed description, we refer to the [README of the main package](https://github.com/theseanl/tscc).

--- a/packages/rollup-plugin-tscc/src/MultiMap.ts
+++ b/packages/rollup-plugin-tscc/src/MultiMap.ts
@@ -47,6 +47,9 @@ export default class MultiMap<K, V> {
 	keys() {
 		return this.map.keys();
 	}
+	get size() {
+		return this.map.size;
+	}
 	static fromObject<V>(object: {[key: string]: V[]}): MultiMap<string, V> {
 		const map = new MultiMap<string, V>();
 		for (let [key, values] of Object.entries(object)) {

--- a/packages/rollup-plugin-tscc/src/goog_shim_mixin.ts
+++ b/packages/rollup-plugin-tscc/src/goog_shim_mixin.ts
@@ -17,6 +17,7 @@ const moduleNameToShim = new Map([
 // Rollup convention, see https://rollupjs.org/guide/en/#conventions
 const PREFIX = "\0tscc\0";
 
+// Interlaces a plugin loading shim files with an existing plugin.
 export function googShimMixin<T extends {resolveId: FunctionPluginHooks["resolveId"], load: FunctionPluginHooks["load"]}>(plugin: T): T {
 	const {resolveId, load} = plugin;
 	plugin.resolveId = function (id, importer) {

--- a/packages/rollup-plugin-tscc/src/index.ts
+++ b/packages/rollup-plugin-tscc/src/index.ts
@@ -124,31 +124,6 @@ const pluginImpl: (options: IInputTsccSpecJSON) => rollup.Plugin = (pluginOption
 		}
 
 		return;
-
-		if (spec.getRollupOutputModuleFormat() === 'iife') {
-			await Promise.all([...entryDeps.keys()].map(async (entry: string) => {
-				// 0. Merge bundles that ought to be merged with this entry point
-				const mergedBundle = await chunkMerger.performSingleEntryBuild(entry, 'iife');
-				// 1. Delete keys for chunks that are included in this merged chunks
-				for (let chunk of chunkAllocation.get(entry)) {
-					delete bundle[chunk];
-				}
-				// 2. Add the merged bundle object
-				bundle[entry] = mergedBundle;
-			}));
-		} else {
-			const mergedChunks = await chunkMerger.performCodeSplittingBuild('es');
-			// 0. Delete keys for chunks that are included in this merged chunks
-			for (let entry of chunkAllocation.keys()) {
-				for (let chunk of chunkAllocation.iterateValues(entry)!) {
-					delete bundle[chunk];
-				}
-			}
-			// 1. Add the merged chunks to the bundle object
-			for (let chunk of mergedChunks) {
-				bundle[chunk.fileName] = chunk;
-			}
-		}
 	});
 
 	return googShimMixin({name, generateBundle, options, outputOptions, resolveId, load});

--- a/packages/rollup-plugin-tscc/src/merge_chunks.ts
+++ b/packages/rollup-plugin-tscc/src/merge_chunks.ts
@@ -4,13 +4,25 @@ import path = require('path');
 import upath = require('upath');
 import {googShimMixin} from './goog_shim_mixin';
 
-export default async function mergeChunks(
+type CodeSplittableModuleFormat = Exclude<rollup.ModuleFormat, 'iife' | 'umd'>;
+
+export async function mergeIIFE(
 	entry: string,
 	chunkAllocation: MultiMap<string, string>,
-	bundle: rollup.OutputBundle,
-	globals?: {[id: string]: string}
+	bundle: Readonly<rollup.OutputBundle>,
+	globals?: {[id: string]: string},
+	format: rollup.ModuleFormat = 'iife'
 ) {
-	return await new ChunkMerger(entry, chunkAllocation, bundle, globals).getBundleOutput();
+	return await new ChunkMerger(chunkAllocation, bundle, globals).performSingleEntryBuild(entry, format);
+}
+
+export async function mergeAllES(
+	chunkAllocation: MultiMap<string, string>,
+	bundle: Readonly<rollup.OutputBundle>,
+	globals?: {[id: string]: string},
+	format: CodeSplittableModuleFormat = 'es'
+) {
+	return await new ChunkMerger(chunkAllocation, bundle, globals).performCodeSplittingBuild(format);
 }
 
 // Merge chunks to their allocated entry chunk.
@@ -19,16 +31,18 @@ export default async function mergeChunks(
 // Each chunk's export object is exported as a separate namespace, whose name is chosen
 // so as not to collide with exported names of the entry module. We pass this namespace
 // as rollup's global option in order to reference those from other chunks.
-class ChunkMerger {
+export class ChunkMerger {
 	private entryModuleNamespaces!: Map<string, string> // Initialized in getBundleOutput call.
 	private chunkNamespaces!: Map<string, string>
 	private unresolveChunk!: Map<string, string>;
 	constructor(
-		private entry: string,
 		private chunkAllocation: MultiMap<string, string>,
 		private bundle: Readonly<rollup.OutputBundle>,
 		private globals?: {[id: string]: string}
-	) {}
+	) {
+		this.populateEntryModuleNamespaces();
+		this.populateUnresolveChunk();
+	}
 	private resolveGlobalForMainBuild(id: string) {
 		if (typeof this.globals !== 'object') return;
 		if (!this.globals.hasOwnProperty(id)) return;
@@ -64,13 +78,13 @@ class ChunkMerger {
 		}
 	}
 	static readonly FACADE_MODULE_ID = `facade.js`;
-	private createFacadeModuleCode(): string {
+	private createFacadeModuleCode(entry: string): string {
 		const importStmts: string[] = [];
 		const exportStmts: string[] = [];
 		// nodejs specification only allows posix-style path separators in module IDs.
-		exportStmts.push(`export * from '${upath.toUnix(this.entry)}'`);
-		for (let chunk of this.chunkAllocation.iterateValues(this.entry)!) {
-			if (chunk === this.entry) continue;
+		exportStmts.push(`export * from '${upath.toUnix(entry)}'`);
+		for (let chunk of this.chunkAllocation.iterateValues(entry)!) {
+			if (chunk === entry) continue;
 			let chunkNs = this.chunkNamespaces.get(chunk);
 			importStmts.push(`import * as ${chunkNs} from '${upath.toUnix(chunk)}'`);
 			exportStmts.push(`export { ${chunkNs} }`);
@@ -78,27 +92,27 @@ class ChunkMerger {
 		const facadeModuleCode = [...importStmts, ...exportStmts].join('\n');
 		return facadeModuleCode;
 	}
-	private createLoaderPlugin(): rollup.Plugin {
+	private createLoaderPlugin(entry: string): rollup.Plugin {
 		const {bundle} = this;
 		const resolveId: rollup.ResolveIdHook = (id, importer) => {
 			if (id === ChunkMerger.FACADE_MODULE_ID) return id;
 			if (this.resolveGlobalForMainBuild(id)) {return {id, external: true}}
-			if (this.chunkAllocation.find(this.entry, id)) return id;
+			if (this.chunkAllocation.find(entry, id)) return id;
 			if (importer) {
 				const resolved = path.resolve(path.dirname(importer), id);
 				let unresolved = this.unresolveChunk.get(resolved);
 				if (typeof unresolved === 'string') {
 					let allocatedEntry = this.chunkAllocation.findValue(unresolved);
-					if (allocatedEntry === this.entry) return unresolved;
+					if (allocatedEntry === entry) return unresolved;
 					return {id: resolved, external: "absolute"}
 				}
 			}
 			// This code path should not be taken
-			throw new ChunkMergeError(`Unexpected module in output chunk: ${id}, ${importer}`);
+			ChunkMerger.throwUnexpectedModuleError(id, importer);
 		};
 		const load: rollup.LoadHook = (id) => {
-			if (id === ChunkMerger.FACADE_MODULE_ID) return this.createFacadeModuleCode();
-			if (this.chunkAllocation.find(this.entry, id)) {
+			if (id === ChunkMerger.FACADE_MODULE_ID) return this.createFacadeModuleCode(entry);
+			if (this.chunkAllocation.find(entry, id)) {
 				let outputChunk = <rollup.OutputChunk>bundle[id];
 				return {
 					code: outputChunk.code,
@@ -106,7 +120,33 @@ class ChunkMerger {
 				}
 			}
 			// This code path should not be taken
-			throw new ChunkMergeError(`Unexpected module in output chunk: ${id}`);
+			ChunkMerger.throwUnexpectedModuleError(id);
+		};
+		const name = "tscc-merger";
+		return googShimMixin({name, resolveId, load});
+	}
+	private createLoaderPlugin2(): rollup.Plugin {
+		const resolveId: rollup.ResolveIdHook = (id, importer) => {
+			if (this.resolveGlobalForMainBuild(id)) {return {id, external: true}}
+			if (this.bundle[id]) return id;
+			if (importer) {
+				const resolved = path.resolve(path.dirname(importer), id);
+				let unresolved = this.unresolveChunk.get(resolved);
+				if (typeof unresolved === 'string') {
+					if (this.bundle[unresolved]) return unresolved;
+					return {id: resolved, external: "absolute"};
+				}
+			}
+			// This code path should not be taken
+			ChunkMerger.throwUnexpectedModuleError(id, importer);
+		};
+		const load: rollup.LoadHook = (id) => {
+			let outputChunk = this.bundle[id] as rollup.OutputChunk | undefined;
+			if (!outputChunk) ChunkMerger.throwUnexpectedModuleError(id);
+			return {
+				code: outputChunk.code,
+				map: toInputSourceMap(outputChunk.map)
+			};
 		};
 		const name = "tscc-merger";
 		return googShimMixin({name, resolveId, load});
@@ -121,53 +161,90 @@ class ChunkMerger {
 		// The below case means that the chunk being queried shouldn't be global. Rollup expects
 		// outputOption.globals to return its input unchanged for non-global module ids, but this
 		// code path won't and shouldn't be taken.
-		if (allocated === this.entry) ChunkMerger.throwUnexpectedModuleError(id);
+		// if (allocated === this.entry) ChunkMerger.throwUnexpectedModuleError(id);
 		// Resolve to <namespace-of-entry-module-that-our-chunk-is-allocated>.<namespace-of-our-chunk>
 		let ns = this.entryModuleNamespaces.get(allocated)!;
 		if (allocated !== id) ns += '.' + this.chunkNamespaces.get(id);
 		return ns;
 	}
-	// TODO: inherit outputOption provided by the caller
-	async getBundleOutput(): Promise<rollup.OutputChunk> {
-		this.populateEntryModuleNamespaces();
+	/**
+	 * Merges chunks for a single entry point, making output bundles reference each other by
+	 * variables in global scope. We control global variable names via `output.globals` option.
+	 * TODO: inherit outputOption provided by the caller
+	 */
+	async performSingleEntryBuild(entry: string, format: rollup.ModuleFormat): Promise<rollup.OutputChunk> {
 		this.populateChunkNamespaces();
-		this.populateUnresolveChunk();
 		const myBundle = await rollup.rollup({
 			input: ChunkMerger.FACADE_MODULE_ID,
-			plugins: [this.createLoaderPlugin()]
+			plugins: [this.createLoaderPlugin(entry)]
 		});
 		const {output} = await myBundle.generate({
-			name: this.entryModuleNamespaces.get(this.entry),
-			format: 'iife',
+			...ChunkMerger.baseOutputOption,
+			name: this.entryModuleNamespaces.get(entry),
 			file: ChunkMerger.FACADE_MODULE_ID,
+			format,
 			globals: (id) => this.resolveGlobal(id),
-			interop: "esModule",
-			esModule: false,
-			freeze: false
 		});
 		if (output.length > 1) {
-			throw new ChunkMergeError("Subbundles should have only one output");
+			ChunkMerger.throwUnexpectedChunkInSecondaryBundleError(output);
 		}
 		const mergedBundle = output[0];
 
 		// 0. Fix fileName to that of entry file
-		mergedBundle.fileName = this.entry;
+		mergedBundle.fileName = entry;
 		// 1. Remove facadeModuleId, as it would point to our virtual module
 		mergedBundle.facadeModuleId = null;
 		// 2. Fix name to that of entry file
-		const name = (<rollup.OutputChunk>this.bundle[this.entry]).name;
+		const name = (<rollup.OutputChunk>this.bundle[entry]).name;
 		Object.defineProperty(mergedBundle, 'name', {
-			get() {
-				return name;
-			}
+			get() {return name;} // TODO: FIXME
 		});
 		// 3. Remove virtual module from .modules
 		delete mergedBundle.modules[ChunkMerger.FACADE_MODULE_ID];
 
 		return mergedBundle
 	}
-	private static throwUnexpectedModuleError(id: string): never {
-		throw new ChunkMergeError(`Unexpected module in output chunk: ${id}`);
+	/**
+	 * We perform the usual rollup bundling which does code splitting. Note that this is unavailable
+	 * for iife and umd builds. In order to control which chunks are emitted, we control them by
+	 * feeding `chunkAllocation` information to rollup via `output.manualChunks` option.
+	 * TODO: inherit outputOption provided by the caller
+	 */
+	async performCodeSplittingBuild(format: CodeSplittableModuleFormat) {
+		const myBundle = await rollup.rollup({
+			input: [...this.chunkAllocation.keys()],
+			plugins: [this.createLoaderPlugin2()],
+			// If this is not set, rollup may create "facade modules" for each of entry modules,
+			// which somehow "leaks" from `manualChunks`. On the other hand, setting this may make
+			// rollup to drop `export` statements in entry files from final chunks. However, Closure
+			// Compiler does this anyway, so it is ok in terms of the goal of this plugin, which
+			// aims to provide an isomorphic builds.
+			preserveEntrySignatures: false
+		});
+		const {output} = await myBundle.generate({
+			...ChunkMerger.baseOutputOption,
+			dir: '.', format,
+			manualChunks: (id: string) => {
+				let allocatedEntry = this.chunkAllocation.findValue(id);
+				if (!allocatedEntry) ChunkMerger.throwUnexpectedModuleError(id);
+				return trimExtension(allocatedEntry);
+			},
+		});
+		if (output.length > this.chunkAllocation.size) {
+			ChunkMerger.throwUnexpectedChunkInSecondaryBundleError(output);
+		}
+		return output as rollup.OutputChunk[];
+	}
+	private static readonly baseOutputOption: rollup.OutputOptions = {
+		interop: 'esModule',
+		esModule: false,
+		freeze: false
+	}
+	private static throwUnexpectedModuleError(id: string, importer = ""): never {
+		throw new ChunkMergeError(`Unexpected module in primary bundle output: ${id} ${importer}`);
+	}
+	private static throwUnexpectedChunkInSecondaryBundleError(output: (rollup.OutputChunk | rollup.OutputAsset)[]) {
+		throw new ChunkMergeError(`Unexpected chunk in secondary bundle output: ${output[output.length - 1].name}. Please report this error.`)
 	}
 }
 
@@ -181,3 +258,6 @@ function toInputSourceMap(sourcemap: rollup.SourceMap | undefined): rollup.Exist
 	return {...sourcemap};
 }
 
+function trimExtension(name: string) {
+	return name.slice(0, name.length - path.extname(name).length)
+}

--- a/packages/rollup-plugin-tscc/src/spec/ITsccSpecRollupFacade.ts
+++ b/packages/rollup-plugin-tscc/src/spec/ITsccSpecRollupFacade.ts
@@ -1,5 +1,6 @@
 import {ITsccSpec} from '@tscc/tscc-spec'
 import MultiMap from '../MultiMap';
+import {ModuleFormat} from 'rollup';
 
 export default interface ITsccSpecRollupFacade extends ITsccSpec {
 	resolveRollupExternalDeps(id: string): string
@@ -18,5 +19,9 @@ export default interface ITsccSpecRollupFacade extends ITsccSpec {
 	 * Returns a key-value pair that can be directly used to rollup output.globals option.
 	 */
 	getRollupExternalModuleNamesToGlobalMap(): {[moduleName: string]: string}
+	/**
+	 * Returns a module format that final bundles will use, based on spec.chunkFormat.
+	 */
+	getRollupOutputModuleFormat(): ModuleFormat
 }
 

--- a/packages/rollup-plugin-tscc/src/spec/TsccSpecRollupFacade.ts
+++ b/packages/rollup-plugin-tscc/src/spec/TsccSpecRollupFacade.ts
@@ -1,6 +1,7 @@
 import {TsccSpec, TsccSpecError} from '@tscc/tscc-spec';
 import ITsccSpecRollupFacade from './ITsccSpecRollupFacade'
 import MultiMap from '../MultiMap';
+import {ModuleFormat} from 'rollup';
 
 export default class TsccSpecRollupFacade extends TsccSpec implements ITsccSpecRollupFacade {
 	resolveRollupExternalDeps(moduleId: string) {
@@ -55,6 +56,15 @@ export default class TsccSpecRollupFacade extends TsccSpec implements ITsccSpecR
 			globals[moduleName] = globalName;
 		}
 		return globals;
+	}
+	getRollupOutputModuleFormat(): ModuleFormat {
+		switch (this.tsccSpec.chunkFormat) {
+			case 'module':
+				return 'es';
+			case 'global':
+			default:
+				return 'iife';
+		}
 	}
 }
 

--- a/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
+++ b/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
@@ -11,6 +11,17 @@ exports[`Golden Tests: external-modules/tscc.spec.json: packages/rollup-plugin-t
 "
 `;
 
+exports[`Golden Tests: external-modules/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules\\golden\\generated_entry 1`] = `
+"(function (externalInNodeModules, externalWithFilePaths) {
+	'use strict';
+
+	console.log(externalInNodeModules.someProperty);
+	console.log(externalWithFilePaths.anotherProperty);
+
+})(externalInNodeModules, externalWithFilePaths);
+"
+`;
+
 exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_dependent 1`] = `
 "(function (_, b) {
 	'use strict';
@@ -24,6 +35,50 @@ exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: pac
 `;
 
 exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_entry 1`] = `
+"var generated_entry = (function (exports, c, a) {
+	'use strict';
+
+	function common(n) {
+		console.log(\\"common\\");
+	}
+	console.log(c.a);
+
+	function entry() {
+		common();
+		console.log(\\"entry\\");
+	}
+
+	entry();
+	console.log(a);
+
+	var _ = {
+		__proto__: null,
+		c: common,
+		e: entry
+	};
+
+	exports.$0 = _;
+	exports.entry = entry;
+
+	return exports;
+
+})({}, c, a);
+"
+`;
+
+exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules-in-many-module-build\\golden\\generated_dependent 1`] = `
+"(function (_, b) {
+	'use strict';
+
+	_.c();
+	_.e();
+	console.log(b);
+
+})(generated_entry.$0, b);
+"
+`;
+
+exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules-in-many-module-build\\golden\\generated_entry 1`] = `
 "var generated_entry = (function (exports, c, a) {
 	'use strict';
 
@@ -115,6 +170,103 @@ exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/tes
 "
 `;
 
+exports[`Golden Tests: goog-shim/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\goog-shim\\golden\\generated_dependent 1`] = `
+"(function (_) {
+	'use strict';
+
+	/**
+	 * @fileoverview Hand-modified shim file for Closure Library \`goog/reflect.js\`. References to the
+	 * global \`goog\` variables have been removed.
+	 */
+
+	function objectProperty(prop, object) {
+		return prop;
+	}
+
+	var dictionary = {
+		\\"key\\": \\"value\\"
+	};
+
+	if (_.g.name === objectProperty(\\"key\\")) {
+		console.log(dictionary[_.g.name]);
+	}
+
+})(generated_entry.$0);
+"
+`;
+
+exports[`Golden Tests: goog-shim/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\goog-shim\\golden\\generated_entry 1`] = `
+"var generated_entry = (function (exports) {
+	'use strict';
+
+	/**
+	 * @fileoverview Hand-modified shim file for Closure Library \`goog/goog.js\`. References to the
+	 * global \`goog\` variables have been removed.
+	 */
+	const global = self; // Use rollup \\"context\\" option to prevent \`this\` rewrite
+
+	let DEBUG = true;
+
+	function isDebugging() {
+		return DEBUG;
+	}
+
+	{
+		console.log(\\"Debugging\\");
+	}
+
+	var _ = {
+		__proto__: null,
+		g: global,
+		i: isDebugging
+	};
+
+	exports.$0 = _;
+	exports.isDebugging = isDebugging;
+
+	return exports;
+
+})({});
+"
+`;
+
+exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_dependent 1`] = `
+"import { g as global } from './generated_entry.js';
+
+/**
+ * @fileoverview Hand-modified shim file for Closure Library \`goog/reflect.js\`. References to the
+ * global \`goog\` variables have been removed.
+ */
+
+function objectProperty(prop, object) {
+	return prop;
+}
+
+var dictionary = {
+	\\"key\\": \\"value\\"
+};
+
+if (global.name === objectProperty(\\"key\\")) {
+	console.log(dictionary[global.name]);
+}
+"
+`;
+
+exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_entry 1`] = `
+"/**
+ * @fileoverview Hand-modified shim file for Closure Library \`goog/goog.js\`. References to the
+ * global \`goog\` variables have been removed.
+ */
+const global = self; // Use rollup \\"context\\" option to prevent \`this\` rewrite
+
+{
+	console.log(\\"Debugging\\");
+}
+
+export { global as g };
+"
+`;
+
 exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/many-module-build/golden/generated_dependent 1`] = `
 "(function (_) {
 	'use strict';
@@ -154,5 +306,72 @@ exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-
 	return exports;
 
 })({});
+"
+`;
+
+exports[`Golden Tests: many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\many-module-build\\golden\\generated_dependent 1`] = `
+"(function (_) {
+	'use strict';
+
+	console.log(_.s([1, _.b]));
+
+})(generated_entry.$0);
+"
+`;
+
+exports[`Golden Tests: many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\many-module-build\\golden\\generated_entry 1`] = `
+"var generated_entry = (function (exports) {
+	'use strict';
+
+	function swap([a, b]) {
+		return [b, a];
+	}
+
+	function sort([a, b]) {
+		return a > b ? [a, b] : swap([a, b]);
+	}
+
+	const a = [1, 2];
+	const b = swap(a);
+
+	console.log(b);
+
+	var _ = {
+		__proto__: null,
+		b: b,
+		s: sort
+	};
+
+	exports.$0 = _;
+	exports.b = b;
+
+	return exports;
+
+})({});
+"
+`;
+
+exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_dependent 1`] = `
+"import { s as sort, b } from './generated_entry.js';
+
+console.log(sort([1, b]));
+"
+`;
+
+exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_entry 1`] = `
+"function swap([a, b]) {
+	return [b, a];
+}
+
+function sort([a, b]) {
+	return a > b ? [a, b] : swap([a, b]);
+}
+
+const a = [1, 2];
+const b = swap(a);
+
+console.log(b);
+
+export { b, sort as s };
 "
 `;

--- a/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
+++ b/packages/rollup-plugin-tscc/test/__snapshots__/golden_test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Golden Tests: external-modules/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules/golden/generated_entry 1`] = `
+exports[`Golden Tests: external-modules/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules/golden/generated_entry.js 1`] = `
 "(function (externalInNodeModules, externalWithFilePaths) {
 	'use strict';
 
@@ -11,18 +11,7 @@ exports[`Golden Tests: external-modules/tscc.spec.json: packages/rollup-plugin-t
 "
 `;
 
-exports[`Golden Tests: external-modules/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules\\golden\\generated_entry 1`] = `
-"(function (externalInNodeModules, externalWithFilePaths) {
-	'use strict';
-
-	console.log(externalInNodeModules.someProperty);
-	console.log(externalWithFilePaths.anotherProperty);
-
-})(externalInNodeModules, externalWithFilePaths);
-"
-`;
-
-exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_dependent 1`] = `
+exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_dependent.js 1`] = `
 "(function (_, b) {
 	'use strict';
 
@@ -34,7 +23,7 @@ exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: pac
 "
 `;
 
-exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_entry 1`] = `
+exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/external-modules-in-many-module-build/golden/generated_entry.js 1`] = `
 "var generated_entry = (function (exports, c, a) {
 	'use strict';
 
@@ -66,51 +55,7 @@ exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: pac
 "
 `;
 
-exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules-in-many-module-build\\golden\\generated_dependent 1`] = `
-"(function (_, b) {
-	'use strict';
-
-	_.c();
-	_.e();
-	console.log(b);
-
-})(generated_entry.$0, b);
-"
-`;
-
-exports[`Golden Tests: external-modules-in-many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\external-modules-in-many-module-build\\golden\\generated_entry 1`] = `
-"var generated_entry = (function (exports, c, a) {
-	'use strict';
-
-	function common(n) {
-		console.log(\\"common\\");
-	}
-	console.log(c.a);
-
-	function entry() {
-		common();
-		console.log(\\"entry\\");
-	}
-
-	entry();
-	console.log(a);
-
-	var _ = {
-		__proto__: null,
-		c: common,
-		e: entry
-	};
-
-	exports.$0 = _;
-	exports.entry = entry;
-
-	return exports;
-
-})({}, c, a);
-"
-`;
-
-exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/goog-shim/golden/generated_dependent 1`] = `
+exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/goog-shim/golden/generated_dependent.js 1`] = `
 "(function (_) {
 	'use strict';
 
@@ -135,7 +80,7 @@ exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/tes
 "
 `;
 
-exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/goog-shim/golden/generated_entry 1`] = `
+exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/goog-shim/golden/generated_entry.js 1`] = `
 "var generated_entry = (function (exports) {
 	'use strict';
 
@@ -170,67 +115,7 @@ exports[`Golden Tests: goog-shim/tscc.spec.json: packages/rollup-plugin-tscc/tes
 "
 `;
 
-exports[`Golden Tests: goog-shim/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\goog-shim\\golden\\generated_dependent 1`] = `
-"(function (_) {
-	'use strict';
-
-	/**
-	 * @fileoverview Hand-modified shim file for Closure Library \`goog/reflect.js\`. References to the
-	 * global \`goog\` variables have been removed.
-	 */
-
-	function objectProperty(prop, object) {
-		return prop;
-	}
-
-	var dictionary = {
-		\\"key\\": \\"value\\"
-	};
-
-	if (_.g.name === objectProperty(\\"key\\")) {
-		console.log(dictionary[_.g.name]);
-	}
-
-})(generated_entry.$0);
-"
-`;
-
-exports[`Golden Tests: goog-shim/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\goog-shim\\golden\\generated_entry 1`] = `
-"var generated_entry = (function (exports) {
-	'use strict';
-
-	/**
-	 * @fileoverview Hand-modified shim file for Closure Library \`goog/goog.js\`. References to the
-	 * global \`goog\` variables have been removed.
-	 */
-	const global = self; // Use rollup \\"context\\" option to prevent \`this\` rewrite
-
-	let DEBUG = true;
-
-	function isDebugging() {
-		return DEBUG;
-	}
-
-	{
-		console.log(\\"Debugging\\");
-	}
-
-	var _ = {
-		__proto__: null,
-		g: global,
-		i: isDebugging
-	};
-
-	exports.$0 = _;
-	exports.isDebugging = isDebugging;
-
-	return exports;
-
-})({});
-"
-`;
-
-exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_dependent 1`] = `
+exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_dependent.js 1`] = `
 "import { g as global } from './generated_entry.js';
 
 /**
@@ -252,7 +137,7 @@ if (global.name === objectProperty(\\"key\\")) {
 "
 `;
 
-exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_entry 1`] = `
+exports[`Golden Tests: goog-shim/tscc.spec.module.json module: generated_entry.js 1`] = `
 "/**
  * @fileoverview Hand-modified shim file for Closure Library \`goog/goog.js\`. References to the
  * global \`goog\` variables have been removed.
@@ -267,7 +152,7 @@ export { global as g };
 "
 `;
 
-exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/many-module-build/golden/generated_dependent 1`] = `
+exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/many-module-build/golden/generated_dependent.js 1`] = `
 "(function (_) {
 	'use strict';
 
@@ -277,7 +162,7 @@ exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-
 "
 `;
 
-exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/many-module-build/golden/generated_entry 1`] = `
+exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-tscc/test/sample/many-module-build/golden/generated_entry.js 1`] = `
 "var generated_entry = (function (exports) {
 	'use strict';
 
@@ -309,56 +194,14 @@ exports[`Golden Tests: many-module-build/tscc.spec.json: packages/rollup-plugin-
 "
 `;
 
-exports[`Golden Tests: many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\many-module-build\\golden\\generated_dependent 1`] = `
-"(function (_) {
-	'use strict';
-
-	console.log(_.s([1, _.b]));
-
-})(generated_entry.$0);
-"
-`;
-
-exports[`Golden Tests: many-module-build/tscc.spec.json: packages\\rollup-plugin-tscc\\test\\sample\\many-module-build\\golden\\generated_entry 1`] = `
-"var generated_entry = (function (exports) {
-	'use strict';
-
-	function swap([a, b]) {
-		return [b, a];
-	}
-
-	function sort([a, b]) {
-		return a > b ? [a, b] : swap([a, b]);
-	}
-
-	const a = [1, 2];
-	const b = swap(a);
-
-	console.log(b);
-
-	var _ = {
-		__proto__: null,
-		b: b,
-		s: sort
-	};
-
-	exports.$0 = _;
-	exports.b = b;
-
-	return exports;
-
-})({});
-"
-`;
-
-exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_dependent 1`] = `
+exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_dependent.js 1`] = `
 "import { s as sort, b } from './generated_entry.js';
 
 console.log(sort([1, b]));
 "
 `;
 
-exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_entry 1`] = `
+exports[`Golden Tests: many-module-build/tscc.spec.module.json module: generated_entry.js 1`] = `
 "function swap([a, b]) {
 	return [b, a];
 }

--- a/packages/rollup-plugin-tscc/test/golden_test.ts
+++ b/packages/rollup-plugin-tscc/test/golden_test.ts
@@ -3,31 +3,39 @@ import tsccPlugin from '../src/index';
 import * as rollup from 'rollup';
 import fg = require('fast-glob');
 import path = require('path');
+import upath = require('upath');
 
 const samplesRoot = path.join(__dirname, 'sample');
 // Using cwd as __dirname in order to produce jest snapshots that are independent of cwd.
 // Providing cwd in order to produce jest snapshots that are independent of cwd calling jest
-const bundleSpecs = <string[]>fg.sync(`*/tscc.spec.json`, {cwd: samplesRoot});
+
+function upathGlob(glob: string): string[] {
+	return fg.sync(glob, {cwd: samplesRoot})
+		.map(p => upath.toUnix(p)); // Normalize so that snapshots have the same name on Linux and on Windows
+}
 
 describe(`Golden Tests:`, () => {
-	test.each(bundleSpecs)(`%s`, async (specPath) => {
-		const specFile = path.join(samplesRoot, specPath);
-		const bundle = await rollup.rollup({
-			plugins: [
-				tsccPlugin({specFile})
-			]
-		});
-		const {output} = await bundle.generate({
-			dir: '.',
-			format: 'iife',
-			interop: 'esModule'
-		});
+	const bundleSpecs = upathGlob(`*/tscc.spec.json`);
+	const moduleBundleSpecs = upathGlob(`*/tscc.spec.module.json`);
 
-
-		Object.keys(output).sort().forEach(name => {
-			let chunk = output[name];
-			expect(chunk.code).toMatchSnapshot(chunk.name);
-		})
-	})
+	test.each(bundleSpecs)(`%s`, testBundle);
+	test.each(moduleBundleSpecs)(`%s module`, testBundle);
 })
 
+async function testBundle(specPath: string) {
+	const specFile = path.join(samplesRoot, specPath);
+	const bundle = await rollup.rollup({
+		plugins: [
+			tsccPlugin({specFile})
+		]
+	});
+	const {output} = await bundle.generate({
+		dir: '.',
+		interop: 'esModule'
+	});
+
+	Object.keys(output).sort().forEach(name => {
+		let chunk = output[name];
+		expect(chunk.code).toMatchSnapshot(chunk.name);
+	})
+}

--- a/packages/rollup-plugin-tscc/test/golden_test.ts
+++ b/packages/rollup-plugin-tscc/test/golden_test.ts
@@ -27,7 +27,13 @@ async function testBundle(specPath: string) {
 	const bundle = await rollup.rollup({
 		plugins: [
 			tsccPlugin({specFile})
-		]
+		],
+		onwarn(warning, warn) {
+			// Silence warning "The 'this' keyword is equivalent to 'undefined' at the top level of
+			// an ES module, and has been rewritten"
+			if (warning.code === 'THIS_IS_UNDEFINED') return;
+			warn(warning);
+		}
 	});
 	const {output} = await bundle.generate({
 		dir: '.',
@@ -36,6 +42,7 @@ async function testBundle(specPath: string) {
 
 	Object.keys(output).sort().forEach(name => {
 		let chunk = output[name];
-		expect(chunk.code).toMatchSnapshot(chunk.name);
+		let normalizedChunkFileName = upath.toUnix(chunk.fileName);
+		expect(chunk.code).toMatchSnapshot(normalizedChunkFileName);
 	})
 }

--- a/packages/rollup-plugin-tscc/test/merge_chunks.ts
+++ b/packages/rollup-plugin-tscc/test/merge_chunks.ts
@@ -1,5 +1,5 @@
 ///<reference types="jest"/>
-import { mergeAllES, mergeIIFE } from "../src/merge_chunks";
+import {mergeAllES, mergeIIFE} from "../src/merge_chunks";
 import MultiMap from "../src/MultiMap";
 import * as rollup from "rollup";
 import path = require("path");
@@ -328,7 +328,7 @@ describe(`mergeChunk`, function () {
 		const entry2 = "entry2.js";
 		const chunk1 = "chunk1.js";
 		const externalRelative = "external_relative";
-		const externalAbsolute = path.resolve("external/absolute.js");
+		const externalAbsolute = path.posix.resolve("external/absolute.js"); // Always use forward slash
 		const chunkAllocation = MultiMap.fromObject({
 			[entry]: [chunk1, entry],
 			[entry2]: [entry2],

--- a/packages/rollup-plugin-tscc/test/merge_chunks.ts
+++ b/packages/rollup-plugin-tscc/test/merge_chunks.ts
@@ -1,7 +1,8 @@
 ///<reference types="jest"/>
-import mergeChunk from "../src/merge_chunks";
+import { mergeAllES, mergeIIFE } from "../src/merge_chunks";
 import MultiMap from "../src/MultiMap";
 import * as rollup from "rollup";
+import path = require("path");
 
 describe(`mergeChunk`, function () {
 	test(`merges chunks for a single entry`, async function () {
@@ -29,7 +30,7 @@ describe(`mergeChunk`, function () {
 				name: "chunk-1",
 			}),
 		};
-		const mergedChunk = await mergeChunk(entry, chunkAllocation, bundle);
+		const mergedChunk = await mergeIIFE(entry, chunkAllocation, bundle);
 
 		expect(mergedChunk.name).toBe("entry");
 		expect(mergedChunk.code).toMatchInlineSnapshot(`
@@ -92,7 +93,7 @@ describe(`mergeChunk`, function () {
 				name: "chunk-1",
 			}),
 		};
-		const mergedChunk = await mergeChunk(entry, chunkAllocation, bundle);
+		const mergedChunk = await mergeIIFE(entry, chunkAllocation, bundle);
 
 		expect(mergedChunk.name).toBe("entry");
 		expect(mergedChunk.code).toMatchInlineSnapshot(`
@@ -190,8 +191,8 @@ describe(`mergeChunk`, function () {
 				name: "chunk-4",
 			}),
 		};
-		const mergedChunk = await mergeChunk(entry, chunkAllocation, bundle);
-		const anotherMergedChunk = await mergeChunk(anotherEntry, chunkAllocation, bundle);
+		const mergedChunk = await mergeIIFE(entry, chunkAllocation, bundle);
+		const anotherMergedChunk = await mergeIIFE(anotherEntry, chunkAllocation, bundle);
 		expect(mergedChunk.code).toMatchInlineSnapshot(`
 		"var entry = (function (exports, chunk2_js, chunk3_js) {
 			'use strict';
@@ -276,8 +277,8 @@ describe(`mergeChunk`, function () {
 	});
 	test(`Correctly merge chunks referencing external modules`, async function () {
 		const chunkAllocation = MultiMap.fromObject({
-			"entry.js": ["external", "entry.js"],
-			"entry2.js": ["external", "entry2.js"],
+			"entry.js": ["entry.js"],
+			"entry2.js": ["entry2.js"],
 		});
 		const bundle: rollup.OutputBundle = {
 			"entry.js": mockChunk({
@@ -296,15 +297,14 @@ describe(`mergeChunk`, function () {
 		const globals = {
 			external: "External",
 		};
-		const mergedChunk = await mergeChunk("entry.js", chunkAllocation, bundle, globals);
-		const anotherMergedChunk = await mergeChunk("entry2.js", chunkAllocation, bundle, globals);
+		const mergedChunk = await mergeIIFE("entry.js", chunkAllocation, bundle, globals);
+		const anotherMergedChunk = await mergeIIFE("entry2.js", chunkAllocation, bundle, globals);
 		expect(mergedChunk.code).toMatchInlineSnapshot(`
 		"var entry = (function (exports, A) {
 			'use strict';
 
 			console.log(A); const a = 1;
 
-			exports.$0 = A;
 			exports.a = a;
 
 			return exports;
@@ -313,19 +313,223 @@ describe(`mergeChunk`, function () {
 		"
 	`);
 		expect(anotherMergedChunk.code).toMatchInlineSnapshot(`
-		"var entry2 = (function (exports, A, entry_js) {
+		"(function (A, entry_js) {
 			'use strict';
 
 			console.warn(A); console.log(entry_js.a);
 
-			exports.$0 = A;
-
-			return exports;
-
-		})({}, External, entry);
+		})(External, entry);
 		"
 	`);
 	});
+
+	test(`Correctly merge chunks referencing external modules via relative paths`, async function () {
+		const entry = "entry.js";
+		const entry2 = "entry2.js";
+		const chunk1 = "chunk1.js";
+		const externalRelative = "external_relative";
+		const externalAbsolute = path.resolve("external/absolute.js");
+		const chunkAllocation = MultiMap.fromObject({
+			[entry]: [chunk1, entry],
+			[entry2]: [entry2],
+		});
+		const bundle: rollup.OutputBundle = {
+			[entry]: mockChunk({
+				fileName: entry,
+				code:
+					`import { C } from "${externalRelative}";` +
+					`import { D } from "${externalAbsolute}";` +
+					`export const c = C + D;`,
+				exports: ["c"],
+				name: "entry",
+			}),
+			[entry2]: mockChunk({
+				fileName: entry2,
+				code:
+					`import { a } from "${externalRelative}";` +
+					`import { e } from "${chunk1}";` +
+					`export const d = a;` +
+					`export const f = e;`,
+				exports: ["d"],
+				name: "entry2",
+			}),
+			[chunk1]: mockChunk({
+				fileName: chunk1,
+				code:
+					`import { A } from "${externalAbsolute}";` +
+					`import { B } from "${externalRelative}";` +
+					`export const e = A + B;`,
+				exports: ["e"],
+				name: "chunk1",
+			}),
+		};
+		const globals = {
+			[externalRelative]: "ExternalRelative",
+			[externalAbsolute]: "ExternalAbsolute",
+		};
+
+		const [mergedChunk, mergedChunk2] = await Promise.all([
+			mergeIIFE(entry, chunkAllocation, bundle, globals),
+			mergeIIFE(entry2, chunkAllocation, bundle, globals),
+		]);
+		expect(mergedChunk.code).toMatchInlineSnapshot(`
+		"var entry = (function (exports, absolute_js, external_relative) {
+			'use strict';
+
+			const e = absolute_js.A + external_relative.B;
+
+			var chunk1 = {
+				__proto__: null,
+				e: e
+			};
+
+			const c = external_relative.C + absolute_js.D;
+
+			exports.$0 = chunk1;
+			exports.c = c;
+
+			return exports;
+
+		})({}, ExternalAbsolute, ExternalRelative);
+		"
+	`);
+		expect(mergedChunk2.code).toMatchInlineSnapshot(`
+		"var entry2 = (function (exports, external_relative, chunk1_js) {
+			'use strict';
+
+			const d = external_relative.a;const f = chunk1_js.e;
+
+			exports.d = d;
+			exports.f = f;
+
+			return exports;
+
+		})({}, ExternalRelative, entry.$0);
+		"
+	`);
+	});
+
+	test(`merges chunk without external modules in ES6 modules format`, async function () {
+		const entry = "entry.js";
+		const entry2 = "entry2.js";
+		const chunk1 = "chunk1.js";
+		const chunkAllocation = MultiMap.fromObject({
+			[entry]: [chunk1, entry],
+			[entry2]: [entry2],
+		});
+		const bundle: rollup.OutputBundle = {
+			[entry]: mockChunk({
+				fileName: entry,
+				code:
+					`import { a, sum } from '${chunk1}'; ` +
+					`export const c = sum(a, 1); ` +
+					`console.log(sum(c, -1)); `,
+				exports: ["c"],
+			}),
+			[entry2]: mockChunk({
+				fileName: entry2,
+				code:
+					`import { b, sum } from "${chunk1}"; ` +
+					`export const d = b + 2; ` +
+					`export function add3(a, b, c) { return sum(sum(a, b), c); } ` +
+					`console.log(add3(1, 2, 3)); `,
+				exports: ["d"],
+			}),
+			[chunk1]: mockChunk({
+				fileName: chunk1,
+				code:
+					`export const a = 3; ` +
+					`export const b = 4; ` +
+					`export function sum(a, b) { return a + b; } `,
+				exports: ["a", "b"],
+			}),
+		};
+		const [mergedESModuleChunk, mergedESModuleChunk2] = await mergeAllES(
+			chunkAllocation,
+			bundle,
+			{},
+			"es"
+		);
+		expect(mergedESModuleChunk.code).toMatchInlineSnapshot(`
+		"const a = 3; function sum(a, b) { return a + b; }
+
+		const c = sum(a, 1); console.log(sum(c, -1));
+
+		export { sum as s };
+		"
+	`);
+		expect(mergedESModuleChunk2.code).toMatchInlineSnapshot(`
+		"import { s as sum } from './entry.js';
+
+		function add3(a, b, c) { return sum(sum(a, b), c); } console.log(add3(1, 2, 3));
+		"
+	`);
+	});
+	test(`merges chunk containing external modules in ES6 module format`, async function () {
+		const entry = "entry.js";
+		const entry2 = "entry2.js";
+		const chunk1 = "chunk1.js";
+		const externalNonAbsolute = "external";
+		const chunkAllocation = MultiMap.fromObject({
+			[entry]: [chunk1, entry],
+			[entry2]: [entry2],
+		});
+		const bundle: rollup.OutputBundle = {
+			[entry]: mockChunk({
+				fileName: entry,
+				code: `import { sum } from "${externalNonAbsolute}";` + `console.log(sum(1, 2));`,
+				exports: ["c"],
+			}),
+			[entry2]: mockChunk({
+				fileName: entry2,
+				code:
+					`import { multiply } from "${externalNonAbsolute}";` +
+					`import { sum3 } from "${chunk1}";` +
+					`console.log(sum3(1, 2, multiply(3, 4)));`,
+				exports: ["d"],
+			}),
+			[chunk1]: mockChunk({
+				fileName: chunk1,
+				code:
+					`import { sum } from "${externalNonAbsolute}";` +
+					`export function sum3(a, b, c) {
+						return sum(a, sum(b, c));
+					};`,
+				exports: ["e"],
+			}),
+		};
+		const globals = {
+			[externalNonAbsolute]: "ExternalNonAbsolute",
+		};
+		const [mergedESModuleChunk, mergedESModuleChunk2] = await mergeAllES(
+			chunkAllocation,
+			bundle,
+			globals,
+			"es"
+		);
+		expect(mergedESModuleChunk.code).toMatchInlineSnapshot(`
+		"import { sum } from 'external';
+
+		console.log(sum(1, 2));
+
+		function sum3(a, b, c) {
+								return sum(a, sum(b, c));
+							}
+
+		export { sum3 as s };
+		"
+	`);
+		expect(mergedESModuleChunk2.code).toMatchInlineSnapshot(`
+		"import { multiply } from 'external';
+		import { s as sum3 } from './entry.js';
+
+		console.log(sum3(1, 2, multiply(3, 4)));
+		"
+	`);
+	});
+	test.todo(
+		`merges chunk containing external modules referenced via relative path in ES6 module format`
+	);
 });
 
 function mockChunk(chunk: Partial<rollup.OutputChunk>): rollup.OutputChunk {

--- a/packages/rollup-plugin-tscc/test/sample/goog-shim/tscc.spec.module.json
+++ b/packages/rollup-plugin-tscc/test/sample/goog-shim/tscc.spec.module.json
@@ -1,0 +1,16 @@
+{
+	"modules": {
+		"entry": "./entry.js",
+		"dependent": {
+			"entry": "./dependent.js",
+			"dependencies": [
+				"entry"
+			]
+		}
+	},
+	"prefix": {
+		"rollup": "./golden/generated_",
+		"cc": "."
+	},
+	"chunkFormat": "module"
+}

--- a/packages/rollup-plugin-tscc/test/sample/many-module-build/tscc.spec.module.json
+++ b/packages/rollup-plugin-tscc/test/sample/many-module-build/tscc.spec.module.json
@@ -1,0 +1,16 @@
+{
+	"modules": {
+		"entry": "./entry.js",
+		"dependent": {
+			"entry": "./dir/dependency.js",
+			"dependencies": [
+				"entry"
+			]
+		}
+	},
+	"prefix": {
+		"rollup": "./golden/generated_",
+		"cc": "."
+	},
+	"chunkFormat": "module"
+}

--- a/packages/tscc-spec/package.json
+++ b/packages/tscc-spec/package.json
@@ -9,6 +9,7 @@
 	},
 	"dependencies": {
 		"fast-glob": "^3.2.11",
-		"fs-extra": "^10.1.0"
+		"fs-extra": "^10.1.0",
+		"upath": "^2.0.1"
 	}
 }

--- a/packages/tscc-spec/src/ITsccSpecJSON.ts
+++ b/packages/tscc-spec/src/ITsccSpecJSON.ts
@@ -58,6 +58,13 @@ declare interface ITsccSpecJSON {
 	 */
 	prefix?: string | {readonly rollup: string, readonly cc: string}
 	/**
+	 * Indicates what format should the output chunks be in. In `global`, chunks will reference
+	 * other chunks' values via global scope. In `module`, chunks will use ES6 import and export
+	 * statements to reference other chunk's values. This mirrors --chunk_output_type option of
+	 * closure compiler. Default is `global`.
+	 */
+	chunkFormat?: 'global' | 'module'
+	/**
 	 * Compiler flags to be passed to closure compiler. Tscc treats it as an opaque data.
 	 * "js", "chunk", "entry_point": computed from <modules>
 	 * "chunk_output_path_prefix": computed from <prefix>

--- a/packages/tscc-spec/src/ITsccSpecJSON.ts
+++ b/packages/tscc-spec/src/ITsccSpecJSON.ts
@@ -25,21 +25,6 @@ export interface INamedModuleSpecs extends IModule {
 	moduleName: string
 }
 
-export declare interface IStyles {
-	/**
-	 * A list of file paths, which will be compiled to a single css file.
-	 */
-	src: ReadonlyArray<string>
-	/**
-	 * A prefix that will be prepended to renamed class names.
-	 */
-	prefix?: string
-	/**
-	 * A list of module names in which the renaming map will be injected.
-	 */
-	modules?: ReadonlyArray<string>
-}
-
 declare interface ITsccSpecJSON {
 	modules: {
 		/**
@@ -77,7 +62,7 @@ declare interface ITsccSpecJSON {
 	 * "js", "chunk", "entry_point": computed from <modules>
 	 * "chunk_output_path_prefix": computed from <prefix>
 	 * "language_in": computed from "compilerOption.target" of tsconfig
-	 * "language_out:; defaults to "ECMASCRIPT5".
+	 * "language_out:; defaults to "ECMASCRIPT_NEXT".
 	 * "compilation_level": defaults to "ADVANCED".
 	 * Input files, output files, input language, and so on are inferred from other settings,
 	 * and if provided here, it will override the inferred values.
@@ -87,12 +72,6 @@ declare interface ITsccSpecJSON {
 	 * Array of paths of soy files.
 	 */
 	templates?: ReadonlyArray<string>
-	styles?: {
-		/**
-		 * A file path of the output css. It supports path delimiters.
-		 */
-		[styleName: string]: Readonly<IStyles>
-	}
 	debug?: IDebugOptions
 }
 

--- a/packages/tscc-spec/src/TsccSpec.ts
+++ b/packages/tscc-spec/src/TsccSpec.ts
@@ -6,6 +6,7 @@ import fs = require('fs');
 import process = require('process');
 import {readJsonSync} from 'fs-extra';
 import fg = require('fast-glob');
+import upath = require('upath');
 
 // "modules" key is no longer required
 interface IInputTsccSpecJSONWithSpecFile extends Partial<ITsccSpecJSON> {
@@ -248,8 +249,12 @@ export default class TsccSpec implements ITsccSpec {
 		if (typeof jsFiles === 'string') {
 			jsFiles = [jsFiles];
 		}
-		// resolve globs according to TSCC's convention
-		jsFiles = jsFiles.map(this.absolute, this);
+		/**
+		 * Resolve globs following TSCC's convention of using the spec file's path as a base path.
+		 * fast-glob expects Unix-style paths. See:
+		 * {@link https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows}
+		 */
+		jsFiles = jsFiles.map(jsFile => upath.toUnix(this.absolute(jsFile)));
 		return <string[]>fg.sync(jsFiles)
 	}
 	debug(): Readonly<IDebugOptions> {

--- a/packages/tscc-spec/src/TsccSpec.ts
+++ b/packages/tscc-spec/src/TsccSpec.ts
@@ -141,6 +141,23 @@ export default class TsccSpec implements ITsccSpec {
 	) {
 		this.computeOrderedModuleSpecs();
 		this.resolveRelativeExternalModuleNames();
+		this.validateSpec();
+	}
+	private validateSpec() {
+		// Validates chunkFormat field.
+		const {chunkFormat} = this.tsccSpec;
+		if (typeof chunkFormat === 'string') {
+			if (chunkFormat !== 'global' && chunkFormat !== 'module') {
+				throw new TsccSpecError(`Invalid value of "chunkFormat": ${chunkFormat}, only "global" or "module" is allowed.`);
+			}
+			/**
+			 * {@link https://github.com/theseanl/tscc/issues/724} External module support for
+			 * "chunkFormat": "module" is incomplete. TODO: implement it and remove the validation here.
+			 */
+			if (chunkFormat === 'module' && this.tsccSpec.external) {
+				throw new TsccSpecError(`External modules support is not implemented for "chunkFormat": "module".`);
+			}
+		}
 	}
 	private orderedModuleSpecs!: Required<INamedModuleSpecs>[];
 	private computeOrderedModuleSpecs() {

--- a/packages/tscc-spec/test/TsccSpec.ts
+++ b/packages/tscc-spec/test/TsccSpec.ts
@@ -66,6 +66,14 @@ describe(`TsccSpec`, () => {
 				TsccSpec.loadSpec({specFile: invalidSpecJSONPath})
 			}).toThrowError(TsccSpecError);
 		});
+
+		const unsupportedJSONPath = path.join(__dirname, 'sample/unsupported_spec.json');
+
+		test(`throws when "chunkFormat" value is "module" and "external" option is used.`, () => {
+			expect(() => {
+				TsccSpec.loadSpec({specFile: unsupportedJSONPath})
+			}).toThrowError(TsccSpecError);
+		})
 	});
 	describe(`getExternalModulenames`, () => {
 		const externalModuleSpecPath = path.join(__dirname, 'sample/spec_with_relative_external.json');

--- a/packages/tscc-spec/test/sample/unsupported_spec.json
+++ b/packages/tscc-spec/test/sample/unsupported_spec.json
@@ -1,0 +1,9 @@
+{
+	"modules": {
+		"out": "index.ts"
+	},
+	"external": {
+		"vendor": "vendor"
+	},
+	"chunkFormat": "module"
+}

--- a/packages/tscc/src/shared/escape_goog_identifier.ts
+++ b/packages/tscc/src/shared/escape_goog_identifier.ts
@@ -94,7 +94,6 @@ export function unescapeGoogAdmissibleName(escapedName: string): string {
 					out += String.fromCodePoint(base32Codes);
 					i += 5;
 				} catch (e) {
-					console.log(escapedName);
 					throw new RangeError(`Invalid characters between position ${i + 1} and ${i + 4}`);
 				}
 			}

--- a/packages/tscc/src/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/src/spec/TsccSpecWithTS.ts
@@ -203,6 +203,10 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		[ts.ScriptTarget.ES2022]: "ECMASCRIPT_NEXT",
 		[ts.ScriptTarget.ESNext]: "ECMASCRIPT_NEXT"
 	}
+	private static readonly chunkFormatToCcType = {
+		['global']: "GLOBAL_NAMEESPACE",
+		['module']: "ES_MODULES"
+	}
 	getOutputFileNames(): string[] {
 		return this.getOrderedModuleSpecs()
 			.map(moduleSpec => {
@@ -237,6 +241,9 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 				this.relativeFromCwd(this.getOutputPrefix('cc')) +
 				this.getOrderedModuleSpecs()[0].moduleName + '.js';
 		}
+		defaultFlags["chunk_output_type"] =
+			this.tsccSpec.chunkFormat && TsccSpecWithTS.chunkFormatToCcType[this.tsccSpec.chunkFormat] ||
+			"GLOBAL_NAMESPACE";
 		defaultFlags["generate_exports"] = true;
 		defaultFlags["export_local_property_definitions"] = true;
 

--- a/packages/tscc/src/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/src/spec/TsccSpecWithTS.ts
@@ -168,9 +168,9 @@ export default class TsccSpecWithTS extends TsccSpec implements ITsccSpecWithTS 
 		private projectRoot: string
 	) {
 		super(tsccSpec, basePath);
-		this.validateSpec();
+		this.validateSpecWithTS();
 	}
-	protected validateSpec() {
+	private validateSpecWithTS() {
 		// Checks that each of entry files is provided in tsConfig.
 		const fileNames = this.getAbsoluteFileNamesSet();
 		const modules = this.getOrderedModuleSpecs();

--- a/packages/tscc/src/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/src/spec/TsccSpecWithTS.ts
@@ -3,6 +3,7 @@ import * as ts from 'typescript';
 import ITsccSpecWithTS from './ITsccSpecWithTS';
 import path = require('path');
 
+
 export class TsError extends Error {
 	constructor(
 		public diagnostics: ReadonlyArray<ts.Diagnostic>

--- a/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
+++ b/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
@@ -126,6 +126,29 @@ exports[`tscc e2e case_9_ts_in_node_modules: case_9_ts_in_node_modules/index.js 
 "
 `;
 
+exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1 1`] = `
+Array [
+  "a.js",
+  "b.js",
+  "c.js",
+]
+`;
+
+exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/a.js 1`] = `
+"var b=new (function(){function a(){}a.prototype.g=function(){console.log(\\"methodUsedByA\\")};a.prototype.h=function(){console.log(\\"methodUsedByB\\")};return a}());b.g();console.log(\\"ac\\");
+"
+`;
+
+exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/b.js 1`] = `
+"b.h();console.log(\\"bba\\");console.log(\\"bc\\");
+"
+`;
+
+exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/c.js 1`] = `
+"console.log(\\"ac\\");console.log(\\"bc\\");console.log(\\"cc\\");
+"
+`;
+
 exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_10_unsafe_module_name_and_script_dts 1`] = `
 Array [
   "index.js",

--- a/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
+++ b/packages/tscc/test/e2e/__snapshots__/golden_test.ts.snap
@@ -126,29 +126,6 @@ exports[`tscc e2e case_9_ts_in_node_modules: case_9_ts_in_node_modules/index.js 
 "
 `;
 
-exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1 1`] = `
-Array [
-  "a.js",
-  "b.js",
-  "c.js",
-]
-`;
-
-exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/a.js 1`] = `
-"var b=new (function(){function a(){}a.prototype.g=function(){console.log(\\"methodUsedByA\\")};a.prototype.h=function(){console.log(\\"methodUsedByB\\")};return a}());b.g();console.log(\\"ac\\");
-"
-`;
-
-exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/b.js 1`] = `
-"b.h();console.log(\\"bba\\");console.log(\\"bc\\");
-"
-`;
-
-exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_1/c.js 1`] = `
-"console.log(\\"ac\\");console.log(\\"bc\\");console.log(\\"cc\\");
-"
-`;
-
 exports[`tscc e2e case_10_unsafe_module_name_and_script_dts: case_10_unsafe_module_name_and_script_dts 1`] = `
 Array [
   "index.js",

--- a/packages/tscc/test/spec/TsccSpecWithTS.ts
+++ b/packages/tscc/test/spec/TsccSpecWithTS.ts
@@ -2,6 +2,7 @@
 import TsccSpecWithTS from '../../src/spec/TsccSpecWithTS';
 import * as ts from 'typescript';
 import path = require('path');
+import {TsccSpecError} from '@tscc/tscc-spec';
 
 describe(`TsccSpecWithTS`, () => {
 	describe(`loadTsConfigFromArgs`, () => {
@@ -42,6 +43,17 @@ describe(`TsccSpecWithTS`, () => {
 			expect(parsedConfig.options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeJs);
 			expect(parsedConfig.options.target).toBe(ts.ScriptTarget.ES2016);
 			expect(parsedConfig.options.downlevelIteration).toBe(false);
+		})
+	})
+	describe(`validateSpecWithTS`, () => {
+		test(`throws an error when entry files in the spec isn't included in tsconfig`, () => {
+			expect(() => {
+				TsccSpecWithTS.loadSpecWithTS({
+					modules: {
+						"entry": "./non_existing_file.ts"
+					}
+				}, path.join(__dirname, 'sample/tsconfig.1.json'))
+			}).toThrowError(TsccSpecError);
 		})
 	})
 	describe(`pruneCompilerOptions`, () => {


### PR DESCRIPTION
- [x] Clean up code
- [x] Fix test so that it passes on Windows
- [x] Add documentation in `packages/rollup-plugin-tscc/README.md`
- [x] Add documentation on `spec.chunkFormat` in `README.md`
- [x] Throw an error when `"chunkFormat": "module"` is used in conjunction with `"external"`, until https://github.com/theseanl/tscc/issues/724 is implemented.

---



    adds a new feature that allows users to perform build that
    generates es6 modules as output chunks. Previously, output chunks need
    to be executed in a shared global scope in order for later chunks to
    reference variables in previous chunks. By adding `chunkFormat` key to
    the spec file, the closure compiler build will be done using
    chunk_output_type = ES_MODULES, and rollup build will be done using a
    usual code-splitting build with tight control of each chunk's location
    in the final bundle.

    Currently it does not work with the spec file's `external` option. It
    "sort of" works for rollup, but again it still doesn't work with
    external modules specified with relative paths. On the closure compiler
    side, it is even less clear what should be done, but it seems clear that
    this is the way to go.